### PR TITLE
Fix timing bug in SystemTimerScheduledTaskManager

### DIFF
--- a/src/Unleash/Scheduling/SystemTimerScheduledTaskManager.cs
+++ b/src/Unleash/Scheduling/SystemTimerScheduledTaskManager.cs
@@ -21,58 +21,63 @@ namespace Unleash.Scheduling
         {
             foreach (var task in tasks)
             {
-                var name = task.Name;
+                ConfigureTask(task, cancellationToken);
+            }
+        }
 
-                async void Callback(object state)
+        private void ConfigureTask(IUnleashScheduledTask task, CancellationToken cancellationToken)
+        {
+            var name = task.Name;
+
+            async void Callback(object state)
+            {
+                try
                 {
-                    try
+                    if (!cancellationToken.IsCancellationRequested)
                     {
-                        if (!cancellationToken.IsCancellationRequested)
-                        {
-                            await task.ExecuteAsync(cancellationToken);
-                        }
-                    }
-                    catch (TaskCanceledException taskCanceledException)
-                    {
-                        if (!cancellationToken.IsCancellationRequested)
-                        {
-                            Logger.WarnException($"UNLEASH: Task '{name}' cancelled ...", taskCanceledException);
-                        }
-                    }
-                    catch (Exception ex)
-                    {
-                        Logger.ErrorException($"UNLEASH: Unhandled exception from background task '{name}'.", ex);
-                    }
-                    finally
-                    {
-                        if (cancellationToken.IsCancellationRequested)
-                        {
-                            // Stop the timer.
-                            timers[name].SafeTimerChange(Timeout.Infinite, Timeout.Infinite, ref disposeEnded);
-                        }
+                        await task.ExecuteAsync(cancellationToken);
                     }
                 }
-
-                var dueTime = task.ExecuteDuringStartup
-                    ? TimeSpan.Zero
-                    : task.Interval;
-
-                var period = task.Interval == TimeSpan.Zero
-                    ? Timeout.InfiniteTimeSpan
-                    : task.Interval;
-
-                // Don't start the timer before it has been added to the dictionary.
-                var timer = new Timer(
-                    callback: Callback,
-                    state: null,
-                    dueTime: Timeout.Infinite,
-                    period: Timeout.Infinite);
-
-                timers.Add(name, timer);
-
-                // Now it's ok to start the timer.
-                timer.SafeTimerChange(dueTime, period, ref disposeEnded);
+                catch (TaskCanceledException taskCanceledException)
+                {
+                    if (!cancellationToken.IsCancellationRequested)
+                    {
+                        Logger.WarnException($"UNLEASH: Task '{name}' cancelled ...", taskCanceledException);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Logger.ErrorException($"UNLEASH: Unhandled exception from background task '{name}'.", ex);
+                }
+                finally
+                {
+                    if (cancellationToken.IsCancellationRequested)
+                    {
+                        // Stop the timer.
+                        timers[name].SafeTimerChange(Timeout.Infinite, Timeout.Infinite, ref disposeEnded);
+                    }
+                }
             }
+
+            var dueTime = task.ExecuteDuringStartup
+                ? TimeSpan.Zero
+                : task.Interval;
+
+            var period = task.Interval == TimeSpan.Zero
+                ? Timeout.InfiniteTimeSpan
+                : task.Interval;
+
+            // Don't start the timer before it has been added to the dictionary.
+            var timer = new Timer(
+                callback: Callback,
+                state: null,
+                dueTime: Timeout.Infinite,
+                period: Timeout.Infinite);
+
+            timers.Add(name, timer);
+
+            // Now it's ok to start the timer.
+            timer.SafeTimerChange(dueTime, period, ref disposeEnded);
         }
 
         private bool disposeEnded;

--- a/tests/Unleash.Tests/Scheduling/SystemTimerScheduledTaskManagerTests.cs
+++ b/tests/Unleash.Tests/Scheduling/SystemTimerScheduledTaskManagerTests.cs
@@ -64,8 +64,6 @@ namespace Unleash.Tests.Scheduling
             using (var cts = new CancellationTokenSource())
             using(var scheduler = new SystemTimerScheduledTaskManager())
             {
-                cts.CancelAfter(75);
-
                 var task = new TestBackgroundTask()
                 {
                     ExecutionDelay = TimeSpan.FromMilliseconds(10),
@@ -74,6 +72,9 @@ namespace Unleash.Tests.Scheduling
                 };
 
                 scheduler.Configure(new List<IUnleashScheduledTask>() { task }, cts.Token);
+
+                cts.CancelAfter(75);
+
                 reset.Wait(TimeSpan.FromMilliseconds(200));
                 
                 task.Counter.Should().BeInRange(2, 4);

--- a/tests/Unleash.Tests/Scheduling/SystemTimerScheduledTaskManagerTests.cs
+++ b/tests/Unleash.Tests/Scheduling/SystemTimerScheduledTaskManagerTests.cs
@@ -62,7 +62,7 @@ namespace Unleash.Tests.Scheduling
         {
             using (var reset = new ManualResetEventSlim(false))
             using (var cts = new CancellationTokenSource())
-            using(var scheduler = new SystemTimerScheduledTaskManager())
+            using (var scheduler = new SystemTimerScheduledTaskManager())
             {
                 var task = new TestBackgroundTask()
                 {
@@ -77,7 +77,7 @@ namespace Unleash.Tests.Scheduling
 
                 reset.Wait(TimeSpan.FromMilliseconds(200));
                 
-                task.Counter.Should().BeInRange(2, 4);
+                task.Counter.Should().BeInRange(4, 6);
             }
         }
     }


### PR DESCRIPTION
# Description

Fixes #63 

The fix changes the way the Timer is used. Instead of changing the Timer's dueTime on each callback, dueTime is only used for the initial delay before firing the callback the first time. It uses the period to specify the interval between each firing of the callback. I think this is how the Timer is supposed to be used.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Verified in our production environment, which runs multiple instances of an ASP.NET Core web application in Azure. 

![unleash-bugfix-clip-data-cut](https://user-images.githubusercontent.com/756826/95988845-c4045b80-0e29-11eb-8601-cb4d7fe5114c.png)

Our configuration looks like this:

```csharp
var unleashSettings = new UnleashSettings
{
  AppName = appName,
  InstanceTag = Environment.MachineName,
  SendMetricsInterval = TimeSpan.FromMinutes(1),
  UnleashApi = new Uri(unleashUrl),
  CustomHttpHeaders = new Dictionary<string, string>
  {
    {"Authorization", clientSecret}
  },
  ScheduledTaskManager = new BugfixTimerScheduledTaskManager(logger)
};

var unleash = new DefaultUnleash(unleashSettings);
```
