### PR TITLE
feat: Exposing the currently loaded FeatureToggle collection outside of the…

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@
 
 ## Introduction
 
-Unleash is a feature toggle system, that gives you a great overview over all feature toggles across all your applications and services. It comes with official client implementations for Java, Node.js and Go.
+Unleash Client SDK for .Net. It is compatible with the
+[Unleash-hosted.com SaaS offering](https://www.unleash-hosted.com/) and
+[Unleash Open-Source](https://github.com/finn-no/unleash).
 
 The main motivation for doing feature toggling is to decouple the process for deploying code to production and releasing new features. This helps reducing risk, and allow us to easily manage which features to enable.
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,6 +7,7 @@ os: Visual Studio 2019
 environment:
   DOTNET_CLI_TELEMETRY_OPTOUT: true
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+  CAKE_SETTINGS_SKIPPACKAGEVERSIONCHECK: true
 
 install:
   - choco install gitversion.portable --version 4.0.0 -y

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,7 +20,7 @@ before_build:
   - ps: gitversion /l console /output buildserver 
 
 build_script:
- - ps: .\build.ps1 -Target "AppVeyor"
+ - ps: .\build.ps1 --Target "AppVeyor"
  
 test: off
 

--- a/build.ps1
+++ b/build.ps1
@@ -220,13 +220,13 @@ if (!(Test-Path $CAKE_EXE)) {
 
 # Build Cake arguments
 $cakeArguments = @("$Script");
-if ($Target) { $cakeArguments += "-target=$Target" }
-if ($Configuration) { $cakeArguments += "-configuration=$Configuration" }
-if ($Verbosity) { $cakeArguments += "-verbosity=$Verbosity" }
-if ($ShowDescription) { $cakeArguments += "-showdescription" }
-if ($DryRun) { $cakeArguments += "-dryrun" }
-if ($Experimental) { $cakeArguments += "-experimental" }
-if ($Mono) { $cakeArguments += "-mono" }
+if ($Target) { $cakeArguments += "--target=$Target" }
+if ($Configuration) { $cakeArguments += "--configuration=$Configuration" }
+if ($Verbosity) { $cakeArguments += "--verbosity=$Verbosity" }
+if ($ShowDescription) { $cakeArguments += "--showdescription" }
+if ($DryRun) { $cakeArguments += "--dryrun" }
+if ($Experimental) { $cakeArguments += "--experimental" }
+if ($Mono) { $cakeArguments += "--mono" }
 $cakeArguments += $ScriptArgs
 
 # Start Cake

--- a/build.ps1
+++ b/build.ps1
@@ -220,13 +220,13 @@ if (!(Test-Path $CAKE_EXE)) {
 
 # Build Cake arguments
 $cakeArguments = @("$Script");
-if ($Target) { $cakeArguments += "--target=$Target" }
-if ($Configuration) { $cakeArguments += "--configuration=$Configuration" }
-if ($Verbosity) { $cakeArguments += "--verbosity=$Verbosity" }
-if ($ShowDescription) { $cakeArguments += "--showdescription" }
-if ($DryRun) { $cakeArguments += "--dryrun" }
-if ($Experimental) { $cakeArguments += "--experimental" }
-if ($Mono) { $cakeArguments += "--mono" }
+if ($Target) { $cakeArguments += "-target=$Target" }
+if ($Configuration) { $cakeArguments += "-configuration=$Configuration" }
+if ($Verbosity) { $cakeArguments += "-verbosity=$Verbosity" }
+if ($ShowDescription) { $cakeArguments += "-showdescription" }
+if ($DryRun) { $cakeArguments += "-dryrun" }
+if ($Experimental) { $cakeArguments += "-experimental" }
+if ($Mono) { $cakeArguments += "-mono" }
 $cakeArguments += $ScriptArgs
 
 # Start Cake

--- a/src/Unleash/DefaultUnleash.cs
+++ b/src/Unleash/DefaultUnleash.cs
@@ -1,11 +1,9 @@
-using System;
-
 namespace Unleash
 {
+    using Internal;
     using Logging;
     using Strategies;
     using System.Collections.Generic;
-    using Internal;
     using System.Linq;
     using Unleash.Variants;
 
@@ -63,6 +61,8 @@ namespace Unleash
             Logger.Info($"UNLEASH: Unleash is initialized and configured with: {settings}");
         }
 
+        /// <inheritdoc />
+        public ICollection<FeatureToggle> FeatureToggles => services.ToggleCollection.Instance.Features;
 
         /// <inheritdoc />
         public bool IsEnabled(string toggleName)

--- a/src/Unleash/IUnleash.cs
+++ b/src/Unleash/IUnleash.cs
@@ -12,6 +12,11 @@ namespace Unleash
     public interface IUnleash : IDisposable
     {
         /// <summary>
+        /// Collection of currently loaded Feature Toggles
+        /// </summary>
+        ICollection<FeatureToggle> FeatureToggles { get; }
+
+        /// <summary>
         /// Determines if the given feature toggle is enabled or not, defaulting to <c>false</c> if the toggle cannot be found.
         /// </summary>
         /// <param name="toggleName">The name of the toggle</param>

--- a/src/Unleash/Internal/ActivationStrategy.cs
+++ b/src/Unleash/Internal/ActivationStrategy.cs
@@ -2,7 +2,7 @@ using System.Collections.Generic;
 
 namespace Unleash.Internal
 {
-    internal class ActivationStrategy
+    public class ActivationStrategy
     {
         public string Name { get; }
         public Dictionary<string, string> Parameters { get; }

--- a/src/Unleash/Internal/FeatureToggle.cs
+++ b/src/Unleash/Internal/FeatureToggle.cs
@@ -3,17 +3,19 @@ using Unleash.Variants;
 
 namespace Unleash.Internal
 {
-    internal class FeatureToggle
+    public class FeatureToggle
     {
-        public FeatureToggle(string name, bool enabled, List<ActivationStrategy> strategies, List<VariantDefinition> variants = null)
+        public FeatureToggle(string name, string type, bool enabled, List<ActivationStrategy> strategies, List<VariantDefinition> variants = null)
         {
             Name = name;
+            Type = type;
             Enabled = enabled;
             Strategies = strategies;
             Variants = variants ?? new List<VariantDefinition>();
         }
 
         public string Name { get; }
+        public string Type { get; }
         public bool Enabled { get; }
         public List<ActivationStrategy> Strategies { get; }
 

--- a/src/Unleash/Serialization/JsonSerializerTester.cs
+++ b/src/Unleash/Serialization/JsonSerializerTester.cs
@@ -14,14 +14,14 @@ namespace Unleash.Serialization
     {
         private static readonly ToggleCollection Toggles = new ToggleCollection(new List<FeatureToggle>
         {
-            new FeatureToggle("Feature1", true, new List<ActivationStrategy>()
+            new FeatureToggle("Feature1", "release", true, new List<ActivationStrategy>()
             {
                 new ActivationStrategy("remoteAddress", new Dictionary<string, string>()
                 {
                     {"IPs", "127.0.0.1"}
                 })
             }),
-            new FeatureToggle("feature2", false, new List<ActivationStrategy>()
+            new FeatureToggle("feature2", "release", false, new List<ActivationStrategy>()
             {
                 new ActivationStrategy("userWithId", new Dictionary<string, string>()
                 {

--- a/tests/Unleash.Tests/Mock/MockApiClient.cs
+++ b/tests/Unleash.Tests/Mock/MockApiClient.cs
@@ -12,7 +12,7 @@ namespace Unleash.Tests.Mock
     {
         private static readonly ToggleCollection Toggles = new ToggleCollection(new List<FeatureToggle>
         {
-            new FeatureToggle("one-enabled", true, new List<ActivationStrategy>()
+            new FeatureToggle("one-enabled",  "release", true, new List<ActivationStrategy>()
             {
                 new ActivationStrategy("userWithId", new Dictionary<string, string>(){
                     {"userIds", "userA" }
@@ -24,7 +24,7 @@ namespace Unleash.Tests.Mock
                 new VariantDefinition("Ab", 34, null, new List<VariantOverride>{ new VariantOverride("context", new[] { "a", "b"}) }),
             }
             ),
-            new FeatureToggle("one-disabled", false, new List<ActivationStrategy>()
+            new FeatureToggle("one-disabled",  "release", false, new List<ActivationStrategy>()
             {
                 new ActivationStrategy("userWithId", new Dictionary<string, string>()
                 {

--- a/tests/Unleash.Tests/Serialization/DynamicJsonSerializerTests.cs
+++ b/tests/Unleash.Tests/Serialization/DynamicJsonSerializerTests.cs
@@ -53,13 +53,13 @@ namespace Unleash.Tests.Serialization
 
             var collection = new ToggleCollection(new List<FeatureToggle>()
             {
-                new FeatureToggle("one", true, new List<ActivationStrategy>()
+                new FeatureToggle("one",  "release", true, new List<ActivationStrategy>()
                 {
                     new ActivationStrategy("userByName", new Dictionary<string, string>(){
                         {"Demo", "Demo" }
                     })
                 }),
-                new FeatureToggle("two", false, new List<ActivationStrategy>()
+                new FeatureToggle("two",  "release", false, new List<ActivationStrategy>()
                 {
                     new ActivationStrategy("userByName2", new Dictionary<string, string>()
                     {

--- a/tests/Unleash.Tests/Variants/VariantUtilsTests.cs
+++ b/tests/Unleash.Tests/Variants/VariantUtilsTests.cs
@@ -15,7 +15,7 @@ namespace Unleash.Tests.Variants
         public void ShouldReturnDefaultVariantWhenToggleHasNoVariants()
         {
             // Arrange
-            var toggle = new FeatureToggle("test.variants", true, new List<ActivationStrategy> { defaultStrategy });
+            var toggle = new FeatureToggle("test.variants", "release", true, new List<ActivationStrategy> { defaultStrategy });
             var context = new UnleashContext
             {
                 UserId = "userA",
@@ -41,6 +41,7 @@ namespace Unleash.Tests.Variants
 
             var toggle = new FeatureToggle(
                     "test.variants",
+                    "release",
                     true,
                     new List<ActivationStrategy> { defaultStrategy },
                     new List<VariantDefinition> { v1, v2, v3 });
@@ -72,6 +73,7 @@ namespace Unleash.Tests.Variants
 
             var toggle = new FeatureToggle(
                     "test.variants",
+                    "release",
                     true,
                     new List<ActivationStrategy> { defaultStrategy },
                     new List<VariantDefinition> { v1, v2, v3 });
@@ -101,6 +103,7 @@ namespace Unleash.Tests.Variants
 
             var toggle = new FeatureToggle(
                     "test.variants",
+                    "release",
                     true,
                     new List<ActivationStrategy> { defaultStrategy },
                     new List<VariantDefinition> { v1, v2, v3 });
@@ -131,6 +134,7 @@ namespace Unleash.Tests.Variants
 
             var toggle = new FeatureToggle(
                     "test.variants",
+                    "release",
                     true,
                     new List<ActivationStrategy> { defaultStrategy },
                     new List<VariantDefinition> { v1, v2, v3 });
@@ -161,6 +165,7 @@ namespace Unleash.Tests.Variants
 
             var toggle = new FeatureToggle(
                     "test.variants",
+                    "release",
                     true,
                     new List<ActivationStrategy> { defaultStrategy },
                     new List<VariantDefinition> { v1, v2, v3 });
@@ -193,6 +198,7 @@ namespace Unleash.Tests.Variants
 
             var toggle = new FeatureToggle(
                     "test.variants",
+                    "release",
                     true,
                     new List<ActivationStrategy> { defaultStrategy },
                     new List<VariantDefinition> { v1, v2, v3 });
@@ -226,6 +232,7 @@ namespace Unleash.Tests.Variants
 
             var toggle = new FeatureToggle(
                     "test.variants",
+                    "release",
                     true,
                     new List<ActivationStrategy> { defaultStrategy },
                     new List<VariantDefinition> { v1, v2, v3 });


### PR DESCRIPTION
… sdk.  Adding "Type" to the FeatureToggle class to be consistent with what comes from the api.  Adjusting tests and access modifiers to account for changes.  This addresses issue#66

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

I exposed the ICollection<FeatureToggle> of the currently loaded collection of toggles as a public getter so that it can be access outside of the sdk.   I also added Type property to the FeatureToggle class to make consistent with what's coming across the unleash client api.

Fixes #66 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Ran local unleash server and tested access against for new field and also ensure newly exposed property was accessible properly.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules