### PR TITLE
feat: support project query parameter (#69)

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,22 @@ When your application shuts down, remember to dispose the unleash instance.
 unleash?.Dispose()
 ```
 
+### Configuring projects in unleash client
+
+If you're organizing your feature toggles in `Projects` in Unleash Enterprise, you can specify the `ProjectId` on the `UnleashSettings` to select which project to fetch feature toggles for.
+
+```csharp
+
+var settings = new UnleashSettings()
+{
+    AppName = "dotnet-test",
+    InstanceTag = "instance z",
+    UnleashApi = new Uri("http://unleash.herokuapp.com/api/"),
+    ProjectId = "projectId"
+};
+
+```
+
 ### Feature toggle api
 
 It is really simple to use unleash.

--- a/src/Unleash/Communication/UnleashApiClient.cs
+++ b/src/Unleash/Communication/UnleashApiClient.cs
@@ -18,20 +18,25 @@ namespace Unleash.Communication
         private readonly HttpClient httpClient;
         private readonly IJsonSerializer jsonSerializer;
         private readonly UnleashApiClientRequestHeaders clientRequestHeaders;
+        private readonly string project;
 
         public UnleashApiClient(
             HttpClient httpClient, 
             IJsonSerializer jsonSerializer, 
-            UnleashApiClientRequestHeaders clientRequestHeaders)
+            UnleashApiClientRequestHeaders clientRequestHeaders,
+            string project = null)
         {
             this.httpClient = httpClient;
             this.jsonSerializer = jsonSerializer;
             this.clientRequestHeaders = clientRequestHeaders;
+            this.project = project;
         }
 
         public async Task<FetchTogglesResult> FetchToggles(string etag, CancellationToken cancellationToken)
         {
-            const string resourceUri = "client/features";
+            string resourceUri = "client/features";
+            if (!string.IsNullOrWhiteSpace(this.project))
+                resourceUri += "?project=" + this.project;
 
             using (var request = new HttpRequestMessage(HttpMethod.Get, resourceUri))
             {

--- a/src/Unleash/Communication/UnleashApiClient.cs
+++ b/src/Unleash/Communication/UnleashApiClient.cs
@@ -18,25 +18,25 @@ namespace Unleash.Communication
         private readonly HttpClient httpClient;
         private readonly IJsonSerializer jsonSerializer;
         private readonly UnleashApiClientRequestHeaders clientRequestHeaders;
-        private readonly string project;
+        private readonly string projectId;
 
         public UnleashApiClient(
             HttpClient httpClient, 
             IJsonSerializer jsonSerializer, 
             UnleashApiClientRequestHeaders clientRequestHeaders,
-            string project = null)
+            string projectId = null)
         {
             this.httpClient = httpClient;
             this.jsonSerializer = jsonSerializer;
             this.clientRequestHeaders = clientRequestHeaders;
-            this.project = project;
+            this.projectId = projectId;
         }
 
         public async Task<FetchTogglesResult> FetchToggles(string etag, CancellationToken cancellationToken)
         {
             string resourceUri = "client/features";
-            if (!string.IsNullOrWhiteSpace(this.project))
-                resourceUri += "?project=" + this.project;
+            if (!string.IsNullOrWhiteSpace(this.projectId))
+                resourceUri += "?project=" + this.projectId;
 
             using (var request = new HttpRequestMessage(HttpMethod.Get, resourceUri))
             {

--- a/src/Unleash/Internal/UnleashServices.cs
+++ b/src/Unleash/Internal/UnleashServices.cs
@@ -61,7 +61,7 @@ namespace Unleash
                     InstanceTag = settings.InstanceTag,
                     CustomHttpHeaders = settings.CustomHttpHeaders,
                     CustomHttpHeaderProvider = settings.UnleashCustomHttpHeaderProvider
-                });
+                }, settings.ProjectId);
             }
             else
             {

--- a/src/Unleash/UnleashSettings.cs
+++ b/src/Unleash/UnleashSettings.cs
@@ -50,7 +50,7 @@ namespace Unleash
         public string InstanceTag { get; set; } = GetDefaultInstanceTag();
 
         /// <summary>
-        /// Gets or sets which projects feature toggles are to be used. Feature only available to Enterprise and Unleash-hosted customers.
+        /// Sets the project to fetch feature toggles for.
         /// </summary>
         public string ProjectId { get; set; } = null;
 

--- a/src/Unleash/UnleashSettings.cs
+++ b/src/Unleash/UnleashSettings.cs
@@ -50,6 +50,11 @@ namespace Unleash
         public string InstanceTag { get; set; } = GetDefaultInstanceTag();
 
         /// <summary>
+        /// Gets or sets which projects feature toggles are to be used. Feature only available to Enterprise and Unleash-hosted customers.
+        /// </summary>
+        public string ProjectId { get; set; } = null;
+
+        /// <summary>
         /// Gets or sets the interval in which feature toggle changes are re-fetched.
         /// 
         /// Default: 30 seconds

--- a/tests/Unleash.Tests/Communication/UnleashApiClient_Project_Tests.cs
+++ b/tests/Unleash.Tests/Communication/UnleashApiClient_Project_Tests.cs
@@ -45,5 +45,35 @@ namespace Unleash.Tests.Communication
             messageHandler.SentMessages.Count.Should().Be(1);
             messageHandler.SentMessages.First().RequestUri.Query.Should().Be("?project=" + project);
         }
+
+        [Test]
+        public async Task FetchToggles_WithoutProject()
+        {
+            var apiUri = new Uri("http://unleash.herokuapp.com/api/");
+
+            var jsonSerializer = new DynamicNewtonsoftJsonSerializer();
+            jsonSerializer.TryLoad();
+
+            var requestHeaders = new UnleashApiClientRequestHeaders
+            {
+                AppName = "api-test-client",
+                InstanceTag = "instance1",
+                CustomHttpHeaders = null,
+                CustomHttpHeaderProvider = null
+            };
+
+            var messageHandler = new MockHttpMessageHandler();
+            var httpClient = new HttpClient(messageHandler)
+            {
+                BaseAddress = apiUri,
+                Timeout = TimeSpan.FromSeconds(5)
+            };
+
+            var client = new UnleashApiClient(httpClient, jsonSerializer, requestHeaders);
+            var toggles = await client.FetchToggles("", CancellationToken.None);
+            toggles.Should().NotBeNull();
+            messageHandler.SentMessages.Count.Should().Be(1);
+            messageHandler.SentMessages.First().RequestUri.Query.Should().Be("");
+        }
     }
 }

--- a/tests/Unleash.Tests/Communication/UnleashApiClient_Project_Tests.cs
+++ b/tests/Unleash.Tests/Communication/UnleashApiClient_Project_Tests.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using NUnit.Framework;
+using Unleash.Communication;
+using Unleash.Serialization;
+using Unleash.Tests.Mock;
+
+namespace Unleash.Tests.Communication
+{
+    public class UnleashApiClient_Project_Tests
+    {
+        [Test]
+        public async Task FetchToggles_ForProject()
+        {
+            var apiUri = new Uri("http://unleash.herokuapp.com/api/");
+            var project = "testproject";
+
+            var jsonSerializer = new DynamicNewtonsoftJsonSerializer();
+            jsonSerializer.TryLoad();
+
+            var requestHeaders = new UnleashApiClientRequestHeaders
+            {
+                AppName = "api-test-client",
+                InstanceTag = "instance1",
+                CustomHttpHeaders = null,
+                CustomHttpHeaderProvider = null
+            };
+
+            var messageHandler = new MockHttpMessageHandler();
+            var httpClient = new HttpClient(messageHandler)
+            {
+                BaseAddress = apiUri,
+                Timeout = TimeSpan.FromSeconds(5)
+            };
+
+            var client = new UnleashApiClient(httpClient, jsonSerializer, requestHeaders, project);
+            var toggles = await client.FetchToggles("", CancellationToken.None);
+            toggles.Should().NotBeNull();
+            messageHandler.SentMessages.Count.Should().Be(1);
+            messageHandler.SentMessages.First().RequestUri.Query.Should().Be("?project=" + project);
+        }
+    }
+}

--- a/tests/Unleash.Tests/Mock/MockHttpMessageHandler.cs
+++ b/tests/Unleash.Tests/Mock/MockHttpMessageHandler.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Unleash.Tests.Mock
+{
+    public class MockHttpMessageHandler : HttpMessageHandler
+    {
+        public List<HttpRequestMessage> SentMessages = new List<HttpRequestMessage>();
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            SentMessages.Add(request);
+
+            return Task.FromResult(new HttpResponseMessage(System.Net.HttpStatusCode.OK)
+            {
+                Content = new StringContent("{}", Encoding.UTF8, "application/json")
+            });
+        }
+    }
+}

--- a/tests/Unleash.Tests/Unleash.Tests.csproj
+++ b/tests/Unleash.Tests/Unleash.Tests.csproj
@@ -79,6 +79,7 @@
     <Compile Include="Integration\UnleashContextDefinition.cs" />
     <Compile Include="Metrics\MetricsBucketTests.cs" />
     <Compile Include="Mock\MockApiClient.cs" />
+    <Compile Include="Mock\MockHttpMessageHandler.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Communication\UnleashApiClient_FetchToggles_Tests.cs" />
     <Compile Include="Serialization\JsonNetSerializer.cs" />

--- a/tests/Unleash.Tests/Unleash.Tests.csproj
+++ b/tests/Unleash.Tests/Unleash.Tests.csproj
@@ -68,6 +68,7 @@
   <ItemGroup>
     <Compile Include="BaseTest.cs" />
     <Compile Include="Communication\BaseUnleashApiClientTest.cs" />
+    <Compile Include="Communication\UnleashApiClient_Project_Tests.cs" />
     <Compile Include="Communication\UnleashApiClient_RegisterClient_Tests.cs" />
     <Compile Include="Communication\UnleashApiClient_SendMetrics_Tests.cs" />
     <Compile Include="Communication\UnleashHttpClientFactory_RegisterHttpClient_Tests.cs" />


### PR DESCRIPTION
# Description

This PR aims to add the projectId query parameter feature to the unleash-client-dotnet.
It does this by adding a setting for ProjectId to UnleashSettings. This setting is carried over to UnleashApiClient and there gets added to the feature toggles uri.

Fixes # (issue)
#69 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

It was tested by adding unit tests specifically for this feature and by running the entire test suite.
Also tested by debugging the WebApplication project in this repo with the different projectids from the demo host.
One unittest fails, but that also fails on master without my changes.: `ShouldBeEnabledWhenExpected`

- [x] `UnleashApiClient_Project_Tests.FetchToggles_ForProject`
- [x] `UnleashApiClient_Project_Tests.FetchToggles_WithoutProject`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes