### PR TITLE
feat: flexible rollout support custom stickiness #71

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ The .Net client comes with implementations for the built-in activation strategie
 - GradualRolloutSessionIdStrategy
 - RemoteAddressStrategy
 - ApplicationHostnameStrategy
+- FlexibleRolloutStrategy
 
 Read more about the strategies in [activation-strategy.md](https://github.com/Unleash/unleash/blob/master/docs/activation-strategies.md).
 
@@ -113,6 +114,22 @@ IUnleash unleash = new DefaultUnleash(config, s1, s2);
 ### Unleash context
 
 In order to use some of the common activation strategies you must provide an [unleash-context](https://github.com/Unleash/unleash/blob/master/docs/unleash-context.md).
+
+If you have configured custom stickiness and want to use that with the FlexibleRolloutStrategy or Variants, add the custom stickiness parameters to the Properties dictionary on the Unleash Context:
+
+```csharp
+HttpContext.Current.Items["UnleashContext"] = new UnleashContext
+{
+    UserId = HttpContext.Current.User?.Identity?.Name,
+    SessionId = HttpContext.Current.Session?.SessionID,
+    RemoteAddress = HttpContext.Current.Request.UserHostAddress,
+    Properties = new Dictionary<string, string>
+    {
+        // Obtain "customField" and add it to the context properties
+        { "customField", HttpContext.Current.Items["customField"].ToString() }
+    }
+};
+```
 
 #### UnleashContextProvider
 The provider typically binds the context to the same thread as the request. If you are using Asp.Net the `UnleashContextProvider` will typically be a 'request scoped' instance. 

--- a/src/Unleash/Strategies/FlexibleRolloutStrategy.cs
+++ b/src/Unleash/Strategies/FlexibleRolloutStrategy.cs
@@ -61,10 +61,6 @@ namespace Unleash.Strategies
         {
             switch (stickiness)
             {
-                case "userId":
-                    return context.UserId;
-                case "sessionId":
-                    return context.SessionId;
                 case "random":
                     return randomGenerator();
                 case "default":

--- a/src/Unleash/Strategies/FlexibleRolloutStrategy.cs
+++ b/src/Unleash/Strategies/FlexibleRolloutStrategy.cs
@@ -67,10 +67,12 @@ namespace Unleash.Strategies
                     return context.SessionId;
                 case "random":
                     return randomGenerator();
-                default:
-                    return context.UserId 
-                        ?? context.SessionId 
+                case "default":
+                    return context.UserId
+                        ?? context.SessionId
                         ?? randomGenerator();
+                default:
+                    return context.GetByName(stickiness);
             }
         }
     }

--- a/tests/Unleash.Tests/Strategy/FlexibleRolloutStrategyTest.cs
+++ b/tests/Unleash.Tests/Strategy/FlexibleRolloutStrategyTest.cs
@@ -221,5 +221,103 @@ namespace Unleash.Tests.Strategy
             // Assert
             enabled.Should().BeFalse();
         }
+
+        [Test]
+        public void Should_be_enabled_for_rollout_50_and_custom_stickiness_customField_388()
+        {
+            // Arrange
+            var strategy = new FlexibleRolloutStrategy();
+            var parameters = new Dictionary<string, string>
+            {
+                { "rollout", "50" },
+                { "stickiness", "customField" },
+                { "groupId", "Feature.flexible.rollout.custom.stickiness_50" }
+            };
+            var context = new UnleashContext()
+            {
+                Properties = new Dictionary<string, string>()
+                {
+                    { "customField", "388" }
+                }
+            };
+
+            // Act
+            var enabled = strategy.IsEnabled(parameters, context);
+
+            // Assert
+            enabled.Should().BeTrue();
+        }
+
+        [Test]
+        public void Should_not_be_enabled_for_rollout_50_and_custom_stickiness_customField_402()
+        {
+            // Arrange
+            var strategy = new FlexibleRolloutStrategy();
+            var parameters = new Dictionary<string, string>
+            {
+                { "rollout", "50" },
+                { "stickiness", "customField" },
+                { "groupId", "Feature.flexible.rollout.custom.stickiness_50" }
+            };
+            var context = new UnleashContext
+            {
+                Properties = new Dictionary<string, string>
+                {
+                    { "customField", "402" }
+                }
+            };
+
+            // Act
+            var enabled = strategy.IsEnabled(parameters, context);
+
+            // Assert
+            enabled.Should().BeFalse();
+        }
+
+        [Test]
+        public void Should_not_be_enabled_for_rollout_50_and_custom_stickiness_customField_no_value()
+        {
+            // Arrange
+            var strategy = new FlexibleRolloutStrategy();
+            var parameters = new Dictionary<string, string>
+            {
+                { "rollout", "50" },
+                { "stickiness", "customField" },
+                { "groupId", "Feature.flexible.rollout.custom.stickiness_50" }
+            };
+            var context = new UnleashContext();
+
+            // Act
+            var enabled = strategy.IsEnabled(parameters, context);
+
+            // Assert
+            enabled.Should().BeFalse();
+        }
+
+        [Test]
+        public void Should_be_enabled_for_rollout_100_and_custom_stickiness_customField_any_value()
+        {
+            // Arrange
+            var strategy = new FlexibleRolloutStrategy();
+            var parameters = new Dictionary<string, string>
+            {
+                { "rollout", "100" },
+                { "stickiness", "customField" },
+                { "groupId", "Feature.flexible.rollout.custom.stickiness_100" }
+            };
+            var context = new UnleashContext
+            {
+                Properties = new Dictionary<string, string>
+                {
+                    { "customField", "any_value" }
+                }
+            };
+
+            // Act
+            var enabled = strategy.IsEnabled(parameters, context);
+
+            // Assert
+            enabled.Should().BeTrue();
+        }
     }
 }


### PR DESCRIPTION
# Description

Intends to add support for custom stickiness parameters

Fixes # (issue)

#71 

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

Added four new tests with data from the feature specification

- [x] `Should_be_enabled_for_rollout_50_and_custom_stickiness_customField_388`
- [x] `Should_not_be_enabled_for_rollout_50_and_custom_stickiness_customField_402`
- [x] `Should_not_be_enabled_for_rollout_50_and_custom_stickiness_customField_no_value`
- [x] `Should_be_enabled_for_rollout_100_and_custom_stickiness_customField_any_value`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
