### PR TITLE
nuget: take build parameter as version variable

### DIFF
--- a/src/Unleash/Unleash.csproj
+++ b/src/Unleash/Unleash.csproj
@@ -86,6 +86,14 @@
   </PropertyGroup>
 
   <PropertyGroup>
+    <AssemblyVersion Condition="'$(AssemblyVersion)' == ''">1.0.0</AssemblyVersion>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <FileVersion Condition="'$(FileVersion)' == ''">1.0.0</FileVersion>
+  </PropertyGroup>
+
+  <PropertyGroup>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
     <PackageId>Unleash.Client</PackageId>
@@ -94,8 +102,8 @@
     <Description>Flexible feature toggle client. It supports enabling features runtime, through multiple activation strategies, and allows you to decouple deployment of code from release of new features. Unleash is a feature toggle system that gives you a great overview over all feature toggles across all your applications and services. Read more at: https://github.com/unleash/unleash/</Description>
     <RepositoryUrl>https://github.com/Unleash/unleash-client-dotnet</RepositoryUrl>
     <Version>$(Version)</Version>
-    <AssemblyVersion>$(Version)</AssemblyVersion>
-    <FileVersion>$(Version)</FileVersion>
+    <AssemblyVersion>$(AssemblyVersion)</AssemblyVersion>
+    <FileVersion>$(FileVersion)</FileVersion>
     <RepositoryType>git</RepositoryType>
     <Copyright>Copyright 2020</Copyright>
     <PackageTags>feature-toggle runtime-toggling feature-flags continous delivery unleash</PackageTags>

--- a/src/Unleash/Unleash.csproj
+++ b/src/Unleash/Unleash.csproj
@@ -80,6 +80,11 @@
   <ItemGroup>
     <Folder Include="ClientFactory\" />
   </ItemGroup>
+
+  <PropertyGroup>
+    <Version Condition="'$(Version)' == ''">1.0.0</Version>
+  </PropertyGroup>
+
   <PropertyGroup>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
@@ -88,9 +93,9 @@
     <Owner>Bricks Software</Owner>
     <Description>Flexible feature toggle client. It supports enabling features runtime, through multiple activation strategies, and allows you to decouple deployment of code from release of new features. Unleash is a feature toggle system that gives you a great overview over all feature toggles across all your applications and services. Read more at: https://github.com/unleash/unleash/</Description>
     <RepositoryUrl>https://github.com/Unleash/unleash-client-dotnet</RepositoryUrl>
-    <Version>1.0.0</Version>
-    <AssemblyVersion>1.0.0</AssemblyVersion>
-    <FileVersion>1.0.0</FileVersion>
+    <Version>$(Version)</Version>
+    <AssemblyVersion>$(Version)</AssemblyVersion>
+    <FileVersion>$(Version)</FileVersion>
     <RepositoryType>git</RepositoryType>
     <Copyright>Copyright 2020</Copyright>
     <PackageTags>feature-toggle runtime-toggling feature-flags continous delivery unleash</PackageTags>


### PR DESCRIPTION
# Description

This PR adds support for versioning the NuGet package via build parameter.
If no version number, 1.0.0 will be used (for instance while building locally)

## Type of change

- [x] Infrastructure

# How Has This Been Tested?

Locally by providing various build versions on the command line to msbuild and looking at the outputs of the build
