### PR TITLE
make getvariant public

### DIFF
--- a/src/Unleash/DefaultUnleash.cs
+++ b/src/Unleash/DefaultUnleash.cs
@@ -124,7 +124,7 @@ namespace Unleash
             return GetVariant(toggleName, services.ContextProvider.Context, defaultVariant);
         }
 
-        private Variant GetVariant(string toggleName, UnleashContext context, Variant defaultValue)
+        public Variant GetVariant(string toggleName, UnleashContext context, Variant defaultValue)
         {
             var toggle = GetToggle(toggleName);
 

--- a/src/Unleash/IUnleash.cs
+++ b/src/Unleash/IUnleash.cs
@@ -46,20 +46,27 @@ namespace Unleash
 
         /// <summary>
         /// Get a weighted variant from a feature that is available.
-        /// Should be used with care, is not a sticky variant, will weight by call. 
         /// </summary>
         /// <param name="toggleName">The name of the toggle</param>
-        /// <returns>A weighted variant or null if feature is not available</returns>
+        /// <returns>A weighted variant or Variant.DISABLED_VARIANT if feature is not available</returns>
         Variant GetVariant(string toggleName);
 
         /// <summary>
         /// Get a weighted variant from a feature that is available.
-        /// Should be used with care, is not a sticky variant, will weight by call. 
         /// </summary>
         /// <param name="toggleName">The name of the toggle</param>
-        /// <param name="defaultValue">If a toglge is not found, the default value will be returned. (Default: Variant.DISABLED_VARIANT)</param>
-        /// <returns>A weighted variant or null if feature is not available</returns>
+        /// <param name="defaultValue">If a toggle is not found, the default value will be returned.</param>
+        /// <returns>A weighted variant or the supplied default value if feature is not available</returns>
         Variant GetVariant(string toggleName, Variant defaultValue);
+
+        /// <summary>
+        /// Get a weighted variant from a feature that is available.
+        /// </summary>
+        /// <param name="toggleName">The name of the toggle</param>
+        /// <param name="context">The Unleash context to evaluate the toggle state against</param>
+        /// <param name="defaultValue">If a toggle is not found, the default value will be returned.</param>
+        /// <returns>A weighted variant or the supplied default value if feature is not available</returns>
+        Variant GetVariant(string toggleName, UnleashContext context, Variant defaultValue);
 
         IEnumerable<VariantDefinition> GetVariants(string toggleName);
     }


### PR DESCRIPTION
# Description

Changed the overload of GetVariant that accepts an UnleashContext from being private to public and added it to the IUnleash interface. Updated some comments on the three GetVariant methods since they seem to be outdated regarding return value and stickiness, but I can change this back if I am mistaken.

Fixes [74](https://github.com/Unleash/unleash-client-dotnet/issues/74)

## Type of change

Please delete options that are not relevant.
- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Ran the cake script before and after the change. 3 failing unit tests before and after: Unleash.Tests.Communication.UnleashApiClient tests that do not seem to authenticate properly. Atleast I get a prompt for authentication when I try to reach out to http://unleash.herokuapp.com/api/

# Checklist:

- [ ] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules