### PR TITLE
improvement: convert operators to const strings

### DIFF
--- a/src/Unleash/Internal/Constraint.cs
+++ b/src/Unleash/Internal/Constraint.cs
@@ -7,17 +7,17 @@ namespace Unleash.Internal
     public class Constraint
     {
         public string ContextName { get; private set; }
-        public Operator Operator { get; private set; }
+        public string Operator { get; private set; }
         public string[] Values { get; private set; }
         public string Value { get; internal set; }
         public bool CaseInsensitive { get; private set; }
         public bool Inverted { get; private set; }
 
 
-        public Constraint(string contextName, Operator @operator, bool caseInsensitive, bool inverted, string value, params string[] values)
+        public Constraint(string contextName, string @operator, bool caseInsensitive, bool inverted, string value, params string[] values)
         {
             ContextName = contextName;
-            Operator = @operator;
+            Operator = @operator?.Trim();
             CaseInsensitive = caseInsensitive;
             Values = values;
             Value = value;

--- a/src/Unleash/Internal/Operator.cs
+++ b/src/Unleash/Internal/Operator.cs
@@ -4,6 +4,8 @@ using System.Text;
 
 namespace Unleash.Internal
 {
+    // Compile time checking of constant strings.
+    // Allows for invalid operators without crashing the application
     public class Operator
     {
         public const string IN = nameof(IN);

--- a/src/Unleash/Internal/Operator.cs
+++ b/src/Unleash/Internal/Operator.cs
@@ -4,22 +4,22 @@ using System.Text;
 
 namespace Unleash.Internal
 {
-    public enum Operator
+    public class Operator
     {
-        IN,
-        NOT_IN,
-        STR_ENDS_WITH,
-        STR_STARTS_WITH,
-        STR_CONTAINS,
-        NUM_EQ,
-        NUM_GT,
-        NUM_GTE,
-        NUM_LT,
-        NUM_LTE,
-        DATE_AFTER,
-        DATE_BEFORE,
-        SEMVER_EQ,
-        SEMVER_GT,
-        SEMVER_LT
+        public const string IN = nameof(IN);
+        public const string NOT_IN = nameof(NOT_IN);
+        public const string STR_ENDS_WITH = nameof(STR_ENDS_WITH);
+        public const string STR_STARTS_WITH = nameof(STR_STARTS_WITH);
+        public const string STR_CONTAINS = nameof(STR_CONTAINS);
+        public const string NUM_EQ = nameof(NUM_EQ);
+        public const string NUM_GT = nameof(NUM_GT);
+        public const string NUM_GTE = nameof(NUM_GTE);
+        public const string NUM_LT = nameof(NUM_LT);
+        public const string NUM_LTE = nameof(NUM_LTE);
+        public const string DATE_AFTER = nameof(DATE_AFTER);
+        public const string DATE_BEFORE = nameof(DATE_BEFORE);
+        public const string SEMVER_EQ = nameof(SEMVER_EQ);
+        public const string SEMVER_GT = nameof(SEMVER_GT);
+        public const string SEMVER_LT = nameof(SEMVER_LT);
     }
 }

--- a/src/Unleash/Strategies/ConstraintUtils.cs
+++ b/src/Unleash/Strategies/ConstraintUtils.cs
@@ -39,6 +39,9 @@ namespace Unleash.Strategies
         private static bool ValidateConstraint(Constraint constraint, UnleashContext context)
         {
             var contextValue = context.GetByName(constraint.ContextName);
+            if (constraint.Operator == null)
+                return false;
+
             if (operators.ContainsKey(constraint.Operator))
                 return operators[constraint.Operator].Evaluate(constraint, context);
             else

--- a/src/Unleash/Strategies/ConstraintUtils.cs
+++ b/src/Unleash/Strategies/ConstraintUtils.cs
@@ -7,7 +7,7 @@ namespace Unleash.Strategies
 {
     public class ConstraintUtils
     {
-        static Dictionary<Operator, IConstraintOperator> operators = new Dictionary<Operator, IConstraintOperator>()
+        static Dictionary<string, IConstraintOperator> operators = new Dictionary<string, IConstraintOperator>()
         {
             { Operator.STR_CONTAINS, new StringConstraintOperator() },
             { Operator.STR_ENDS_WITH, new StringConstraintOperator() },

--- a/src/Unleash/Strategies/Constraints/DateConstraintOperator.cs
+++ b/src/Unleash/Strategies/Constraints/DateConstraintOperator.cs
@@ -34,7 +34,7 @@ namespace Unleash.Strategies.Constraints
             return Eval(constraint.Operator, constraintDate, contextDate.Value);
         }
 
-        private bool Eval(Operator @operator, DateTimeOffset constraintDate, DateTimeOffset contextDate)
+        private bool Eval(string @operator, DateTimeOffset constraintDate, DateTimeOffset contextDate)
         {
             if (@operator == Operator.DATE_AFTER)
                 return contextDate > constraintDate;

--- a/src/Unleash/Strategies/Constraints/NumberConstraintOperator.cs
+++ b/src/Unleash/Strategies/Constraints/NumberConstraintOperator.cs
@@ -27,7 +27,7 @@ namespace Unleash.Strategies.Constraints
             return Eval(constraint.Operator, constraintNumber, contextNumber);
         }
 
-        private bool Eval(Operator @operator, double constraintNumber, double contextNumber)
+        private bool Eval(string @operator, double constraintNumber, double contextNumber)
         {
             switch (@operator)
             {

--- a/src/Unleash/Strategies/Constraints/SemverConstraintOperator.cs
+++ b/src/Unleash/Strategies/Constraints/SemverConstraintOperator.cs
@@ -37,7 +37,7 @@ namespace Unleash.Strategies.Constraints
             return false;
         }
 
-        private bool Eval(Operator @operator, SemanticVersion contextSemver, SemanticVersion constraintSemver)
+        private bool Eval(string @operator, SemanticVersion contextSemver, SemanticVersion constraintSemver)
         {
             switch (@operator)
             {

--- a/src/Unleash/Strategies/Constraints/StringConstraintOperator.cs
+++ b/src/Unleash/Strategies/Constraints/StringConstraintOperator.cs
@@ -23,7 +23,7 @@ namespace Unleash.Strategies.Constraints
             return constraint.Values.Any(val => Eval(constraint.Operator, val, contextValue, constraint.CaseInsensitive));
         }
 
-        private bool Eval(Operator @operator, string value, string contextValue, bool caseInsensitive)
+        private bool Eval(string @operator, string value, string contextValue, bool caseInsensitive)
         {
             var comparison = caseInsensitive ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
 

--- a/tests/Unleash.Tests/Strategy/Constraints/ConstraintUtilsTests.cs
+++ b/tests/Unleash.Tests/Strategy/Constraints/ConstraintUtilsTests.cs
@@ -1,0 +1,67 @@
+﻿using FluentAssertions;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Unleash.Internal;
+using Unleash.Strategies;
+
+namespace Unleash.Tests.Strategy.Constraints
+{
+    public class ConstraintUtilsTests
+    {
+        [Test]
+        public void Invalid_Operators_Return_False()
+        {
+            // Setup
+            var constraint = new Constraint("event_date", "INVALID_OPERATOR", false, false, "2022-01-29T13:00:00.000Z");
+            var context = new UnleashContext();
+            context.Properties.Add("event_date", "2022-01-29T15:00:00.000Z");
+
+            // Act
+            var result = ConstraintUtils.Validate(new List<Constraint>() { constraint }, context);
+
+            // Assert
+            result.Should().BeFalse();
+        }
+
+        [Test]
+        public void Operator_Trims_Inputs()
+        {
+            var constraint = new Constraint("event_date", " TRIMMED  ", false, false, "2022-01-29T13:00:00.000Z");
+            constraint.Operator.Should().Be("TRIMMED");
+        }
+
+        [Test]
+        public void ConstraintUtils_Validate_Handles_Nulls()
+        {
+            // Setup
+            var constraint = new Constraint("event_date", null, false, false, "2022-01-29T13:00:00.000Z");
+            var context = new UnleashContext();
+            context.Properties.Add("event_date", "2022-01-29T15:00:00.000Z");
+
+            // Act
+            var result = ConstraintUtils.Validate(new List<Constraint>() { constraint }, context);
+
+            // Assert
+            result.Should().BeFalse();
+        }
+
+        [Test]
+        public void ConstraintUtils_Validate_Handles_Empty()
+        {
+            // Setup
+            var constraint = new Constraint("event_date", "", false, false, "2022-01-29T13:00:00.000Z");
+            var context = new UnleashContext();
+            context.Properties.Add("event_date", "2022-01-29T15:00:00.000Z");
+
+            // Act
+            var result = ConstraintUtils.Validate(new List<Constraint>() { constraint }, context);
+
+            // Assert
+            result.Should().BeFalse();
+        }
+    }
+}


### PR DESCRIPTION
# Description

A potential fix to the problem that invalid operators cast exception and aborts deserialization

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Ran all the spec tests
- [x] Added unit tests

# Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes