### PR TITLE
improvement: fix build versions allow beta.n

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,8 +35,8 @@ jobs:
           NUGET_VERSION: ${{ github.event.release.tag_name }}
         run: |
           echo "nuget=${NUGET_VERSION}" >> $GITHUB_ENV
-          echo "file=${NUGET_VERSION%-beta}" >> $GITHUB_ENV
-          echo "assembly=${NUGET_VERSION%-beta}" >> $GITHUB_ENV
+          echo "file=${NUGET_VERSION%-beta*}" >> $GITHUB_ENV
+          echo "assembly=${NUGET_VERSION%-beta*}" >> $GITHUB_ENV
         shell: bash
 
       - name: Build the solution


### PR DESCRIPTION
# Description

A fix for the issue of release-workflow not removing -beta.n prerelease version info, only -beta

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
