### PR TITLE
Add missing description and stale properties to feature flag type

### DIFF
--- a/src/Unleash/Internal/FeatureToggle.cs
+++ b/src/Unleash/Internal/FeatureToggle.cs
@@ -5,25 +5,36 @@ namespace Unleash.Internal
 {
     public class FeatureToggle
     {
-        public FeatureToggle(string name, string type, bool enabled, List<ActivationStrategy> strategies, List<VariantDefinition> variants = null)
+        public FeatureToggle(
+            string name,
+            string description,
+            string type,
+            bool enabled,
+            bool stale,
+            List<ActivationStrategy> strategies,
+            List<VariantDefinition> variants = null)
         {
             Name = name;
+            Description = description;
             Type = type;
             Enabled = enabled;
+            Stale = stale;
             Strategies = strategies;
             Variants = variants ?? new List<VariantDefinition>();
         }
 
         public string Name { get; }
+        public string Description { get; }
         public string Type { get; }
         public bool Enabled { get; }
+        public bool Stale { get; }
         public List<ActivationStrategy> Strategies { get; }
 
         public List<VariantDefinition> Variants { get; }
 
         public override string ToString()
         {
-            return $"FeatureToggle{{name=\'{Name}{'\''}, enabled={Enabled}, strategies=\'{Strategies}{'\''}{'}'}";
+            return $"FeatureToggle{{name=\'{Name}{'\''}, enabled={Enabled}, stale={Stale}, strategies=\'{Strategies}{'\''}{'}'}";
         }
     }
 }

--- a/src/Unleash/Serialization/JsonSerializerTester.cs
+++ b/src/Unleash/Serialization/JsonSerializerTester.cs
@@ -14,14 +14,14 @@ namespace Unleash.Serialization
     {
         private static readonly ToggleCollection Toggles = new ToggleCollection(new List<FeatureToggle>
         {
-            new FeatureToggle("Feature1", "release", true, new List<ActivationStrategy>()
+            new FeatureToggle("Feature1", "feature 1", "release", true, false, new List<ActivationStrategy>()
             {
                 new ActivationStrategy("remoteAddress", new Dictionary<string, string>()
                 {
                     {"IPs", "127.0.0.1"}
                 })
             }),
-            new FeatureToggle("feature2", "release", false, new List<ActivationStrategy>()
+            new FeatureToggle("feature2", "feature 2", "release", false, false, new List<ActivationStrategy>()
             {
                 new ActivationStrategy("userWithId", new Dictionary<string, string>()
                 {


### PR DESCRIPTION
# Description

Add missing description and stale properties to the feature flag type to be aligned with the unleash server response.
These properties are to be used for management and refactor, for example, properties being marked as stale can be removed from code generation tools and alert the developer to refactor. 

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
Run WebAppCore and see that these properties are being updated and aligned with the remote server result.

**Test Configuration**:
* Firmware version:
* Hardware:
* Toolchain:
* SDK:

# Checklist:

- [ x] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules