### PR TITLE
Changed default SendMetricsInterval to 60s

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -67,12 +67,12 @@ Task("Download-Client-Specifications")
     .Does(() =>
 {
     var indexPath = File("./tests/Unleash.Tests/Integration/Data/index.json");
-    DownloadFile("https://raw.githubusercontent.com/Unleash/client-specification/main/specifications/index.json", indexPath);
+    DownloadFile("https://raw.githubusercontent.com/Unleash/client-specification/v4.1.0/specifications/index.json", indexPath);
 
 	foreach (var fileName in DeserializeJsonFromFile<string[]>(indexPath))
 	{
 		var filePath = File("./tests/Unleash.Tests/Integration/Data/" + fileName);
-		DownloadFile("https://raw.githubusercontent.com/Unleash/client-specification/main/specifications/" + fileName, filePath);
+		DownloadFile("https://raw.githubusercontent.com/Unleash/client-specification/v4.1.0/specifications/" + fileName, filePath);
 	}
 
 });

--- a/build.cake
+++ b/build.cake
@@ -13,6 +13,9 @@ var solutionPath = "./Unleash.sln";
 var unleashProjectFile = "./src/Unleash/Unleash.csproj";
 var buildDir = Directory("./src/Unleash/bin") + Directory(configuration);
 
+var csTestsVersion = "v4.1.0"
+var clientSpecificationTestsURL = string.Format("https://raw.githubusercontent.com/Unleash/client-specification/{0}/specifications/", csTestsVersion);
+
 //
 // TASKS
 //
@@ -67,12 +70,12 @@ Task("Download-Client-Specifications")
     .Does(() =>
 {
     var indexPath = File("./tests/Unleash.Tests/Integration/Data/index.json");
-    DownloadFile("https://raw.githubusercontent.com/Unleash/client-specification/v4.1.0/specifications/index.json", indexPath);
+    DownloadFile(string.format(clientSpecificationTestsURL + "index.json", indexPath);
 
 	foreach (var fileName in DeserializeJsonFromFile<string[]>(indexPath))
 	{
 		var filePath = File("./tests/Unleash.Tests/Integration/Data/" + fileName);
-		DownloadFile("https://raw.githubusercontent.com/Unleash/client-specification/v4.1.0/specifications/" + fileName, filePath);
+		DownloadFile(clientSpecificationTestsURL + fileName, filePath);
 	}
 
 });

--- a/build.cake
+++ b/build.cake
@@ -14,7 +14,7 @@ var unleashProjectFile = "./src/Unleash/Unleash.csproj";
 var buildDir = Directory("./src/Unleash/bin") + Directory(configuration);
 
 var csTestsVersion = "v4.1.0"
-var clientSpecificationTestsURL = "https://raw.githubusercontent.com/Unleash/client-specification/" + csTestsVersion + /specifications/";
+var clientSpecificationTestsURL = "https://raw.githubusercontent.com/Unleash/client-specification/" + csTestsVersion + "/specifications/";
 
 //
 // TASKS

--- a/build.cake
+++ b/build.cake
@@ -14,7 +14,7 @@ var unleashProjectFile = "./src/Unleash/Unleash.csproj";
 var buildDir = Directory("./src/Unleash/bin") + Directory(configuration);
 
 var csTestsVersion = "v4.1.0"
-var clientSpecificationTestsURL = string.Format("https://raw.githubusercontent.com/Unleash/client-specification/{0}/specifications/", csTestsVersion);
+var clientSpecificationTestsURL = "https://raw.githubusercontent.com/Unleash/client-specification/" + csTestsVersion + /specifications/";
 
 //
 // TASKS

--- a/build.cake
+++ b/build.cake
@@ -13,7 +13,7 @@ var solutionPath = "./Unleash.sln";
 var unleashProjectFile = "./src/Unleash/Unleash.csproj";
 var buildDir = Directory("./src/Unleash/bin") + Directory(configuration);
 
-var csTestsVersion = "v4.1.0"
+var csTestsVersion = "v4.1.0";
 var clientSpecificationTestsURL = "https://raw.githubusercontent.com/Unleash/client-specification/" + csTestsVersion + "/specifications/";
 
 //

--- a/build.cake
+++ b/build.cake
@@ -70,7 +70,7 @@ Task("Download-Client-Specifications")
     .Does(() =>
 {
     var indexPath = File("./tests/Unleash.Tests/Integration/Data/index.json");
-    DownloadFile(string.format(clientSpecificationTestsURL + "index.json", indexPath);
+    DownloadFile(clientSpecificationTestsURL + "index.json", indexPath);
 
 	foreach (var fileName in DeserializeJsonFromFile<string[]>(indexPath))
 	{

--- a/src/Unleash/UnleashSettings.cs
+++ b/src/Unleash/UnleashSettings.cs
@@ -63,7 +63,7 @@ namespace Unleash
         public TimeSpan FetchTogglesInterval { get; set; } = TimeSpan.FromSeconds(30);
 
         /// <summary>
-        /// Gets or sets the interval in which metrics are sent to the server. When null, no metrics is sent.
+        /// Gets or sets the interval in which metrics are sent to the server. When null, no metrics are sent.
         /// 
         /// Default: 60s
         /// </summary>

--- a/src/Unleash/UnleashSettings.cs
+++ b/src/Unleash/UnleashSettings.cs
@@ -63,11 +63,11 @@ namespace Unleash
         public TimeSpan FetchTogglesInterval { get; set; } = TimeSpan.FromSeconds(30);
 
         /// <summary>
-        /// Gets or sets the interval in which metriccs are sent to the server. When null, no metrics is sent.
+        /// Gets or sets the interval in which metrics are sent to the server. When null, no metrics is sent.
         /// 
-        /// Default: null
+        /// Default: 60s
         /// </summary>
-        public TimeSpan? SendMetricsInterval { get; set; } = null;
+        public TimeSpan? SendMetricsInterval { get; set; } = TimeSpan.FromSeconds(60);
 
         /// <summary>
         /// Gets or set a directory for storing temporary files (toggles and current etag values). 


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Changes the default SendMetricsInterval to 60s as per our [documentation](https://docs.getunleash.io/sdks#server-side-sdk-compatibility-table)

Fixes # https://github.com/Unleash/unleash-client-dotnet/issues/105

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* Firmware version:
* Hardware:
* Toolchain:
* SDK:

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules