### PR TITLE
issue 114/improvement: move creation of httpclient instance to virtual property

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,33 @@ var settings = new UnleashSettings()
 };
 ```
 
+### HttpMessageHandlers/Custom HttpClient initialization
+If you need to specify HttpMessageHandlers or to control the instantiation of the HttpClient, you can create a custom
+HttpClientFactory that inherits from DefaultHttpClientFactory, and override the method CreateHttpClientInstance.
+Then configure UnleashSettings to use your custom HttpClientFactory. 
+
+```csharp
+internal class CustomHttpClientFactory : DefaultHttpClientFactory
+{
+    protected override HttpClient CreateHttpClientInstance(Uri unleashApiUri)
+    {
+        var messageHandler = new CustomHttpMessageHandler();
+        var httpClient = new HttpClient(messageHandler)
+        {
+            BaseAddress = apiUri,
+            Timeout = TimeSpan.FromSeconds(5)
+        };
+    }
+}
+
+var settings = new UnleashSettings
+{
+    AppName = "dotnet-test",
+    //...
+    HttpClientFactory = new CustomHttpClientFactory()
+};
+```
+
 ### Dynamic custom HTTP headers
 If you need custom http headers that change during the lifetime of the client, a provider can be defined via the `UnleashSettings`. 
 

--- a/src/Unleash/DefaultHttpClientFactory.cs
+++ b/src/Unleash/DefaultHttpClientFactory.cs
@@ -36,11 +36,7 @@ namespace Unleash
 
             return _httpClientCache.GetOrAdd(key, k =>
             {
-                var client = new HttpClient
-                {
-                    BaseAddress = unleashApiUri,
-                    Timeout = Timeout
-                };
+                var client = CreateHttpClientInstance(unleashApiUri);
                 // Refresh DNS cache each 60 seconds
                 var servicePoint = ServicePointManager.FindServicePoint(unleashApiUri);
                 ConfigureServicePoint(servicePoint);
@@ -49,6 +45,17 @@ namespace Unleash
 
                 return client;
             });
+        }
+
+        protected virtual HttpClient CreateHttpClientInstance(Uri unleashApiUri)
+        {
+            var client = new HttpClient
+            {
+                BaseAddress = unleashApiUri,
+                Timeout = Timeout
+            };
+
+            return client;
         }
 
         protected virtual void ConfigureHttpClient(HttpClient httpClient)

--- a/tests/Unleash.Tests/DefaultUnleashTests.cs
+++ b/tests/Unleash.Tests/DefaultUnleashTests.cs
@@ -1,6 +1,7 @@
 ﻿using FluentAssertions;
 using NUnit.Framework;
 using System;
+using Unleash.Tests.Mock;
 
 namespace Unleash.Tests
 {
@@ -26,6 +27,20 @@ namespace Unleash.Tests
 
             // Assert
             callbackCalled.Should().BeTrue();
+        }
+
+        [Test]
+        public void Configure_Http_Client_Factory()
+        {
+            // Arrange
+            var factory = new HttpClientFactoryMock();
+            var apiUri = new Uri("http://localhost:8080/");
+
+            // Act
+            var client = factory.Create(apiUri);
+
+            // Assert
+            factory.CreateHttpClientInstanceCalled.Should().BeTrue();
         }
     }
 }

--- a/tests/Unleash.Tests/Mock/HttpClientFactoryMock.cs
+++ b/tests/Unleash.Tests/Mock/HttpClientFactoryMock.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Unleash.Tests.Mock
+{
+    internal class HttpClientFactoryMock : DefaultHttpClientFactory
+    {
+        public bool CreateHttpClientInstanceCalled { get; private set; }
+
+        protected override HttpClient CreateHttpClientInstance(Uri unleashApiUri)
+        {
+            CreateHttpClientInstanceCalled = true;
+
+            return base.CreateHttpClientInstance(unleashApiUri);
+        }
+
+    }
+}

--- a/tests/Unleash.Tests/Unleash.Tests.csproj
+++ b/tests/Unleash.Tests/Unleash.Tests.csproj
@@ -88,6 +88,7 @@
     <Compile Include="IOTests.cs" />
     <Compile Include="Metrics\MetricsBucketTests.cs" />
     <Compile Include="Mock\ConfigurableMessageHandlerMock.cs" />
+    <Compile Include="Mock\HttpClientFactoryMock.cs" />
     <Compile Include="Mock\MockApiClient.cs" />
     <Compile Include="Mock\MockHttpMessageHandler.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />


### PR DESCRIPTION
# Description

Attempts to solve issue #114 by adding an overrideable method for `HttpClient` instantiation to `DefaultHttpClientFactory`.
Inherit from `DefaultHttpClientFactory` and override the method `CreateHttpClientInstance` to take control of instantiation

Fixes # (issue)
#114 

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

Unit tests

# Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes