### PR TITLE
docs: merge content from docs.getunleash.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ If you create more than 10 instances, Unleash will attempt to log warnings about
 To create a new instance of Unleash you need to create and pass in an `UnleashSettings` object.
 
 When creating an instance of the Unleash client, you can choose to do it either **synchronously** or **asynchronously**.
-The SDK will synchronize with the Unleash API on initialization, so it can take a moment for the client to reach the correct state.
+The SDK will synchronize with the Unleash API on initialization, so it can take a moment for the it to reach the correct state. With an asynchronous startup, this would happen in the background while the rest of your code keeps executing. In most cases, this isn't an issue. But if you want to **wait until the SDK is fully synchronized**, then you should use the configuration explained in the [synchronous startup](#synchronous-startup) section.
 This is usually not an issue and Unleash will do this in the background as soon as you initialize it.
 However, if it's important that you do not continue execution until the SDK has synchronized, then you should use the configuration explained in the [synchronous startup](#synchronous-startup) section.
 

--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ Read more about the strategies in [the activation strategy reference docs](https
 
 ### Custom strategies
 
-You may also specify and implement your own strategies. The specification must be registered in the Unleash UI and you must register the strategy implementation when you wire up unleash.
+You can also specify and implement your own [custom strategies](https://docs.getunleash.io/reference/custom-activation-strategies). The specification must be registered in the Unleash UI and you must register the strategy implementation when you wire up unleash.
 
 ```csharp
 IStrategy s1 = new MyAwesomeStrategy();


### PR DESCRIPTION
This change merges content from docs.getunleash.io into the readme

Most of the content already existed in the readme, so the changes are
primarily rewordings and clarifications.

There's also a few cleanup changes:

- Promote a fair few headings. It seems like a lot of the headings were
mistakenly nested under "Getting started", so I have promoted them so
that they're now they're own proper subsections.
- Updated links to the docs.getunleash.io articles

## Background

We're making a change to the documentation on docs.getunleash.io. Keeping the docs in sync with the SDKs and their readmes is difficult and a lot of manual work, so we've decided to move to generating the SDK documentation from the project readmes. Moving forward, all SDK-specific documentation will be replaced with the SDKs' respective github readmes. (Refer to https://github.com/Unleash/unleash/pull/2809 for more background.)

This PR aims to update this project readme to make sure that no information is lost in this content.

## Type of change

Please delete options that are not relevant.
- [x] This change is a documentation update

# How Has This Been Tested?
N/A

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules