### PR TITLE
[WIP] Add targetframeworks .net 5-7

### DIFF
--- a/.github/workflows/prs.yml
+++ b/.github/workflows/prs.yml
@@ -11,7 +11,7 @@ jobs:
   # This workflow contains a single job called "build"
   build:
     # The type of runner that the job will run on
-    runs-on: windows-2019
+    runs-on: windows-2022
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/.github/workflows/prs.yml
+++ b/.github/workflows/prs.yml
@@ -34,7 +34,7 @@ jobs:
         run: nuget restore Unleash.sln
         
       - name: Build the solution
-        run: msbuild Unleash.sln /p:Configuration=Release
+        run: dotnet build Unleash.sln -p:Configuration=Release
       
       # '& "$(vswhere -property installationPath)\Common7\IDE\Extensions\TestPlatform\vstest.console.exe" tests\Unleash.Tests\bin\Release\Unleash.Tests.dll'
       - name: Run the tests with cake

--- a/.github/workflows/prs.yml
+++ b/.github/workflows/prs.yml
@@ -31,7 +31,7 @@ jobs:
         uses: NuGet/setup-nuget@v1
         
       - name: Restore packages with NuGet
-        run: nuget restore Unleash.sln
+        run: dotnet restore Unleash.sln
         
       - name: Build the solution
         run: dotnet build Unleash.sln -p:Configuration=Release

--- a/.github/workflows/prs.yml
+++ b/.github/workflows/prs.yml
@@ -31,10 +31,10 @@ jobs:
         uses: NuGet/setup-nuget@v1
         
       - name: Restore packages with NuGet
-        run: dotnet restore Unleash.sln
+        run: nuget restore Unleash.sln
         
       - name: Build the solution
-        run: dotnet build Unleash.sln -p:Configuration=Release
+        run: msbuild Unleash.sln /p:Configuration=Release
       
       # '& "$(vswhere -property installationPath)\Common7\IDE\Extensions\TestPlatform\vstest.console.exe" tests\Unleash.Tests\bin\Release\Unleash.Tests.dll'
       - name: Run the tests with cake

--- a/.github/workflows/prs.yml
+++ b/.github/workflows/prs.yml
@@ -20,15 +20,15 @@ jobs:
 
       # Set up MSBuild in PATH for command
       - name: Setup MSBuild in PATH
-        uses: microsoft/setup-msbuild@v1
+        uses: microsoft/setup-msbuild@v1.1
         
-      - uses: actions/setup-dotnet@v1
+      - uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: '5.0.x'
+          dotnet-version: '7.0.x'
 
       # Get NuGet setup for restoring, packaging and pushing
       - name: Setup NuGet
-        uses: NuGet/setup-nuget@v1.0.5
+        uses: NuGet/setup-nuget@v1
         
       - name: Restore packages with NuGet
         run: nuget restore Unleash.sln

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,13 +18,13 @@ jobs:
       - name: Setup MSBuild in PATH
         uses: microsoft/setup-msbuild@v1
 
-      - uses: actions/setup-dotnet@v1
+      - uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: '5.0.x'
+          dotnet-version: '7.0.x'
 
       # Get NuGet setup for restoring, packaging and pushing
       - name: Setup NuGet
-        uses: NuGet/setup-nuget@v1.0.5
+        uses: NuGet/setup-nuget@v1.1
 
       - name: Restore packages with NuGet
         run: nuget restore Unleash.sln

--- a/Unleash.sln
+++ b/Unleash.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
-VisualStudioVersion = 16.0.29001.49
+VisualStudioVersion = 25.0.1704.2
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Unleash", "src\Unleash\Unleash.csproj", "{4CF2127B-8FC8-46FC-8614-3918148463A5}"
 EndProject

--- a/src/Unleash/Unleash.csproj
+++ b/src/Unleash/Unleash.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net47;net461;net46;net451;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net47;net461;net46;net451;net45;net5.0;net6.0;net7.0</TargetFrameworks>
     <RootNamespace>Unleash</RootNamespace>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>

--- a/tests/Unleash.Tests/Unleash.Tests.csproj
+++ b/tests/Unleash.Tests/Unleash.Tests.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="17.4" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\packages\NUnit3TestAdapter.3.15.1\build\net35\NUnit3TestAdapter.props" Condition="Exists('..\..\packages\NUnit3TestAdapter.3.15.1\build\net35\NUnit3TestAdapter.props')" />
   <Import Project="..\..\packages\NUnit.3.12.0\build\NUnit.props" Condition="Exists('..\..\packages\NUnit.3.12.0\build\NUnit.props')" />
   <PropertyGroup>
@@ -13,7 +13,7 @@
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">15.0</VisualStudioVersion>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">17.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
     <IsCodedUITest>False</IsCodedUITest>


### PR DESCRIPTION
# Description

Updates target frameworks to include .NET 5, 6 and 7. Updates gh-actions to build with new runtimes

Fixes # (issue)
#115 

## Type of change

Infrastructure/availability

# How Has This Been Tested?

I've run the build locally and will test by setting up a new test-app to run off of the new dlls

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules