### PR TITLE
docs: Remove references to `InstanceTag`

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,7 +267,6 @@ protected void Application_BeginRequest(object sender, EventArgs e)
 var settings = new UnleashSettings()
 {
     AppName = "dotnet-test",
-    InstanceTag = "instance z",
     UnleashApi = new Uri("http://unleash.herokuapp.com/api/"),
     UnleashContextProvider = new AspNetContextProvider(),
     CustomHttpHeaders = new Dictionary()
@@ -285,7 +284,6 @@ If you want the client to send custom HTTP Headers with all requests to the Unle
 var settings = new UnleashSettings()
 {
     AppName = "dotnet-test",
-    InstanceTag = "instance z",
     UnleashApi = new Uri("http://unleash.herokuapp.com/api/"),
     UnleashContextProvider = new AspNetContextProvider(),
     CustomHttpHeaders = new Dictionary<string, string>()
@@ -368,7 +366,6 @@ Configuring with the UnleashSettings:
 var settings = new UnleashSettings()
 {
     AppName = "dotnet-test",
-    InstanceTag = "instance z",
     UnleashApi = new Uri("http://unleash.herokuapp.com/api/"),
     CustomHttpHeaders = new Dictionary()
     {
@@ -415,7 +412,6 @@ With Newtonsoft.Json version 7.0.0.0, the following implementation can be used. 
 var settings = new UnleashSettings()
 {
     AppName = "dotnet-test",
-    InstanceTag = "instance z",
     UnleashApi = new Uri("http://unleash.herokuapp.com/api/"),
     JsonSerializer = new NewtonsoftJson7Serializer()
 };


### PR DESCRIPTION
## What

This change removes references to `InstanceTag` in the examples.

## Why

1. This property doesn't need to be set. The SDK will generate a default if you don't provide it. Removing it simplifies the examples.

2. This property is never explained anywhere in the readme, so it can
be hard to know what it does and what it's used for. Additionally, the
name `InstanceTag` is different from the `InstanceId` that other SDKs
use, making it confusing even to people somewhat familiar with Unleash.