### PR TITLE
add test to check if flexible rollout handles a null context correctly

### DIFF
--- a/src/Unleash/Strategies/FlexibleRolloutStrategy.cs
+++ b/src/Unleash/Strategies/FlexibleRolloutStrategy.cs
@@ -68,7 +68,7 @@ namespace Unleash.Strategies
                         ?? context?.SessionId
                         ?? randomGenerator();
                 default:
-                    return context?.GetByName(stickiness) ?? randomGenerator();
+                    return context.GetByName(stickiness);
             }
         }
     }

--- a/src/Unleash/Strategies/FlexibleRolloutStrategy.cs
+++ b/src/Unleash/Strategies/FlexibleRolloutStrategy.cs
@@ -64,11 +64,11 @@ namespace Unleash.Strategies
                 case "random":
                     return randomGenerator();
                 case "default":
-                    return context.UserId
-                        ?? context.SessionId
+                    return context?.UserId
+                        ?? context?.SessionId
                         ?? randomGenerator();
                 default:
-                    return context.GetByName(stickiness);
+                    return context?.GetByName(stickiness) ?? randomGenerator();
             }
         }
     }

--- a/tests/Unleash.Tests/Strategy/FlexibleRolloutStrategyTest.cs
+++ b/tests/Unleash.Tests/Strategy/FlexibleRolloutStrategyTest.cs
@@ -327,7 +327,7 @@ namespace Unleash.Tests.Strategy
             var parameters = new Dictionary<string, string>
             {
                 { "rollout", "100" },
-                { "stickiness", "customField" },
+                { "stickiness", "default" },
                 { "groupId", "Feature.flexible.rollout.custom.stickiness_100" }
             };
 

--- a/tests/Unleash.Tests/Strategy/FlexibleRolloutStrategyTest.cs
+++ b/tests/Unleash.Tests/Strategy/FlexibleRolloutStrategyTest.cs
@@ -319,5 +319,23 @@ namespace Unleash.Tests.Strategy
             // Assert
             enabled.Should().BeTrue();
         }
+
+        [Test]
+        public void Should_be_enabled_without_a_context() {
+            // Arrange
+            var strategy = new FlexibleRolloutStrategy();
+            var parameters = new Dictionary<string, string>
+            {
+                { "rollout", "100" },
+                { "stickiness", "customField" },
+                { "groupId", "Feature.flexible.rollout.custom.stickiness_100" }
+            };
+
+            // Act
+            var enabled = strategy.IsEnabled(parameters, null);
+
+            // Assert
+            enabled.Should().BeTrue();
+        }
     }
 }


### PR DESCRIPTION
This allows the flexible rollout strategy to correctly fallback to random when no context is passed. Closes #125 