### PR TITLE
feat: send sdk name during client registration

### DIFF
--- a/src/Unleash/UnleashSettings.cs
+++ b/src/Unleash/UnleashSettings.cs
@@ -142,7 +142,7 @@ namespace Unleash
 
         private static string GetSdkVersion()
         {
-
+            var assemblyName = Assembly.GetExecutingAssembly().GetName();
             var version = assemblyName.Version.ToString(3);
 
             return $"unleash-client-dotnet:v{version}";

--- a/src/Unleash/UnleashSettings.cs
+++ b/src/Unleash/UnleashSettings.cs
@@ -146,7 +146,7 @@ namespace Unleash
             var assemblyName = Assembly.GetExecutingAssembly().GetName();
             var version = assemblyName.Version.ToString(3);
 
-            return $"v{version}";
+            return $"{assemblyName}:v{version}";
         }
 
         private static string GetDefaultInstanceTag()

--- a/src/Unleash/UnleashSettings.cs
+++ b/src/Unleash/UnleashSettings.cs
@@ -143,10 +143,9 @@ namespace Unleash
         private static string GetSdkVersion()
         {
 
-            var assemblyName = Assembly.GetExecutingAssembly().GetName();
             var version = assemblyName.Version.ToString(3);
 
-            return $"{assemblyName}:v{version}";
+            return $"unleash-client-dotnet:v{version}";
         }
 
         private static string GetDefaultInstanceTag()

--- a/tests/Unleash.Tests/UnleashSettingsTests.cs
+++ b/tests/Unleash.Tests/UnleashSettingsTests.cs
@@ -14,5 +14,15 @@ namespace Unleash.Tests
             // Assert
             settings.Environment.Should().Be("default");
         }
+
+        [Test]
+        public void Should_set_sdk_name()
+        {
+            // Act
+            var settings = new UnleashSettings();
+
+            // Assert
+            settings.SdkVersion.Should().Be("awesome");
+        }
     }
 }

--- a/tests/Unleash.Tests/UnleashSettingsTests.cs
+++ b/tests/Unleash.Tests/UnleashSettingsTests.cs
@@ -22,7 +22,7 @@ namespace Unleash.Tests
             var settings = new UnleashSettings();
 
             // Assert
-            settings.SdkVersion.Should().Be("awesome");
+            settings.SdkVersion.Should().StartWith("unleash-client-dotnet:v");
         }
     }
 }


### PR DESCRIPTION
This sets the sdk name as well as the version during the client registration.
