### PR TITLE
Fixes a bug where an app not configuring ImpressionData would throw null refs

### DIFF
--- a/src/Unleash/DefaultUnleash.cs
+++ b/src/Unleash/DefaultUnleash.cs
@@ -265,7 +265,7 @@ namespace Unleash
 
         private void EmitImpressionEvent(string type, UnleashContext context, bool enabled, string name, string variant = null)
         {
-            if (EventConfig.ImpressionEvent == null)
+            if (EventConfig?.ImpressionEvent == null)
             {
                 Logger.Error($"UNLEASH: Unleash->ImpressionData callback is null, unable to emit event");
                 return;

--- a/tests/Unleash.Tests/Internal/ImpressionData_Tests.cs
+++ b/tests/Unleash.Tests/Internal/ImpressionData_Tests.cs
@@ -166,6 +166,31 @@ namespace Unleash.Tests.Internal
             callbackEvent.Variant.Should().Be("blue");
         }
 
+        [Test]
+        public void Unhooked_Impression_Events_Doesnt_Cause_Everything_To_Fail()
+        {
+            // Arrange
+            var appname = "testapp";
+            var strategy = new ActivationStrategy("default", new Dictionary<string, string>(), new List<Constraint>() { new Constraint("item-id", Operator.NUM_EQ, false, false, "1") });
+            var payload = new Payload("string", "val1");
+            var toggles = new List<FeatureToggle>()
+            {
+                new FeatureToggle("yup", "release", true, true, new List<ActivationStrategy>() { strategy })
+            };
+
+
+            var state = new ToggleCollection(toggles);
+            state.Version = 2;
+            var unleash = CreateUnleash(appname, state);
+
+            // Act
+            var enabled = unleash.IsEnabled("yup");
+            unleash.Dispose();
+
+            // Assert
+            enabled.Should().BeTrue();
+        }
+
         public static IUnleash CreateUnleash(string name, ToggleCollection state)
         {
             var fakeHttpClientFactory = A.Fake<IHttpClientFactory>();


### PR DESCRIPTION
# Description
Fixes a bug where an app not configuring ImpressionData would throw null refs on toggles with impression data enabled


Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Added a unit test
- Ran all unit tests

# Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules