### PR TITLE
Add user agent header

### DIFF
--- a/src/Unleash/Communication/UnleashApiClient.cs
+++ b/src/Unleash/Communication/UnleashApiClient.cs
@@ -148,11 +148,13 @@ namespace Unleash.Communication
         private static void SetRequestHeaders(HttpRequestMessage requestMessage, UnleashApiClientRequestHeaders headers)
         {
             const string appNameHeader = "UNLEASH-APPNAME";
+            const string userAgentHeader = "User-Agent";
             const string instanceIdHeader = "UNLEASH-INSTANCEID";
 
             const string supportedSpecVersionHeader = "Unleash-Client-Spec";
 
             requestMessage.Headers.TryAddWithoutValidation(appNameHeader, headers.AppName);
+            requestMessage.Headers.TryAddWithoutValidation(userAgentHeader, headers.AppName);
             requestMessage.Headers.TryAddWithoutValidation(instanceIdHeader, headers.InstanceTag);
             requestMessage.Headers.TryAddWithoutValidation(supportedSpecVersionHeader, headers.SupportedSpecVersion);
 

--- a/tests/Unleash.Tests/Communication/CustomHeadersUnitTest.cs
+++ b/tests/Unleash.Tests/Communication/CustomHeadersUnitTest.cs
@@ -105,6 +105,7 @@ namespace Unleash.Tests.Communication
             messageHandler.calls.Count.Should().Be(3);
             foreach (var call in messageHandler.calls)
             {
+                call.Headers.Should().ContainEquivalentOf(new KeyValuePair<string, IEnumerable<string>>("User-Agent", new string[] { "api-test-client" }));
                 call.Headers.Should().ContainEquivalentOf(new KeyValuePair<string, IEnumerable<string>>("expectedHeader1", new string[] { "expectedValue1" }));
                 call.Headers.Should().ContainEquivalentOf(new KeyValuePair<string, IEnumerable<string>>("expectedHeader2", new string[] { "expectedValue2" }));
             }


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

Unlike the other SDKs (validated in Node and Java), the dotnet SDK does not add the a user agent header. This behavior is inconsistent and can prevent API gateways that are expecting such a header from processing the request.

https://github.com/Unleash/unleash-client-node/blob/main/src/request.ts#L56

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

No current tests exist to validate these internal-only headers in the dotnet project.

Honestly, I cannot get this to build and run the tests locally.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works 
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules