### PR TITLE
feat: warn instead of error and use guid instead of random number

### DIFF
--- a/src/Unleash/Scheduling/FetchFeatureTogglesTask.cs
+++ b/src/Unleash/Scheduling/FetchFeatureTogglesTask.cs
@@ -78,7 +78,7 @@ namespace Unleash.Scheduling
             } 
             catch (IOException ex)
             {
-                Logger.ErrorException($"UNLEASH: Unhandled exception when writing to toggle file '{toggleFile}'.", ex);
+                Logger.WarnException($"UNLEASH: Unhandled exception when writing to toggle file '{toggleFile}'.", ex);
                 eventConfig?.RaiseError(new ErrorEvent() { ErrorType = ErrorType.TogglesBackup, Error = ex });
             }
 
@@ -90,7 +90,7 @@ namespace Unleash.Scheduling
             }
             catch (IOException ex)
             {
-                Logger.ErrorException($"UNLEASH: Unhandled exception when writing to ETag file '{etagFile}'.", ex);
+                Logger.WarnException($"UNLEASH: Unhandled exception when writing to ETag file '{etagFile}'.", ex);
                 eventConfig?.RaiseError(new ErrorEvent() { ErrorType = ErrorType.TogglesBackup, Error = ex });
             }
         }

--- a/src/Unleash/UnleashSettings.cs
+++ b/src/Unleash/UnleashSettings.cs
@@ -152,7 +152,7 @@ namespace Unleash
         {
             var hostName = Dns.GetHostName();
 
-            return $"{hostName}-generated-{Math.Round(new Random().NextDouble() * 1000000.0D)}";
+            return $"{hostName}-generated-{Guid.NewGuid()}";
         }
 
         /// <summary>


### PR DESCRIPTION
# Description

- Writing backup files now warns instead of logging errors.
- Use a GUID instead of a random number to remove collisions

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Running existing tests
- Running in a sample app

# Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules