### PR TITLE
docs: remove comma

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ var settings = new UnleashSettings()
 {
     AppName = "dotnet-test",
     UnleashApi = new Uri("<your-api-url>"),
-    CustomHttpHeaders = new Dictionary<string, string>(),
+    CustomHttpHeaders = new Dictionary<string, string>()
     {
        {"Authorization","<your-api-token>" }
     }


### PR DESCRIPTION
There was a comma before the initializer list of the dictionary which made the code snippet not compile properly.
