### PR TITLE
fix: take settings reference instead and use props

### DIFF
--- a/src/Unleash/Internal/UnleashServices.cs
+++ b/src/Unleash/Internal/UnleashServices.cs
@@ -27,7 +27,10 @@ namespace Unleash
 
         public UnleashServices(UnleashSettings settings, EventCallbackConfig eventConfig, Dictionary<string, IStrategy> strategyMap)
         {
-            var fileSystem = settings.FileSystem ?? new FileSystem(settings.Encoding);
+            if (settings.FileSystem == null)
+            {
+                settings.FileSystem = new FileSystem(settings.Encoding);
+            }
 
             var backupFile = settings.GetFeatureToggleFilePath();
             var etagBackupFile = settings.GetFeatureToggleETagFilePath();
@@ -36,7 +39,7 @@ namespace Unleash
             CancellationToken = cancellationTokenSource.Token;
             ContextProvider = settings.UnleashContextProvider;
 
-            var loader = new CachedFilesLoader(settings.JsonSerializer, fileSystem, settings.ToggleBootstrapProvider, eventConfig, backupFile, etagBackupFile, settings.BootstrapOverride);
+            var loader = new CachedFilesLoader(settings.JsonSerializer, settings.FileSystem, settings.ToggleBootstrapProvider, eventConfig, backupFile, etagBackupFile, settings.BootstrapOverride);
             var cachedFilesResult = loader.EnsureExistsAndLoad();
 
             ToggleCollection = new ThreadSafeToggleCollection
@@ -79,7 +82,7 @@ namespace Unleash
                 apiClient, 
                 ToggleCollection,
                 settings.JsonSerializer, 
-                fileSystem,
+                settings.FileSystem,
                 eventConfig,
                 backupFile, 
                 etagBackupFile)

--- a/src/Unleash/UnleashSettings.cs
+++ b/src/Unleash/UnleashSettings.cs
@@ -215,12 +215,12 @@ namespace Unleash
 
         public void UseBootstrapUrlProvider(string path, bool shouldThrowOnError, Dictionary<string, string> customHeaders = null)
         {
-            ToggleBootstrapProvider = new ToggleBootstrapUrlProvider(path, HttpClientFactory.Create(new Uri(path)), JsonSerializer, shouldThrowOnError, customHeaders);
+            ToggleBootstrapProvider = new ToggleBootstrapUrlProvider(path, HttpClientFactory.Create(new Uri(path)), this, shouldThrowOnError, customHeaders);
         }
 
         public void UseBootstrapFileProvider(string path)
         {
-            ToggleBootstrapProvider = new ToggleBootstrapFileProvider(path, FileSystem, JsonSerializer);
+            ToggleBootstrapProvider = new ToggleBootstrapFileProvider(path, this);
         }
     }
 }

--- a/src/Unleash/Utilities/ToggleBootstrapFileProvider.cs
+++ b/src/Unleash/Utilities/ToggleBootstrapFileProvider.cs
@@ -9,21 +9,18 @@ namespace Unleash.Utilities
     public class ToggleBootstrapFileProvider : IToggleBootstrapProvider
     {
         private readonly string filePath;
-        private readonly IFileSystem fileSystem;
-        private readonly IJsonSerializer jsonSerializer;
+        private readonly UnleashSettings settings;
 
-
-        internal ToggleBootstrapFileProvider(string filePath, IFileSystem fileSystem, IJsonSerializer jsonSerializer)
+        internal ToggleBootstrapFileProvider(string filePath, UnleashSettings settings)
         {
             this.filePath = filePath;
-            this.fileSystem = fileSystem;
-            this.jsonSerializer = jsonSerializer;
+            this.settings = settings;
         }
 
         public ToggleCollection Read()
         {
-            using (var togglesStream = fileSystem.FileOpenRead(filePath))
-                return jsonSerializer.Deserialize<ToggleCollection>(togglesStream);
+            using (var togglesStream = settings.FileSystem.FileOpenRead(filePath))
+                return settings.JsonSerializer.Deserialize<ToggleCollection>(togglesStream);
         }
     }
 }

--- a/src/Unleash/Utilities/ToggleBootstrapUrlProvider.cs
+++ b/src/Unleash/Utilities/ToggleBootstrapUrlProvider.cs
@@ -17,16 +17,16 @@ namespace Unleash.Utilities
 
         private readonly CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
         private readonly HttpClient client;
-        private readonly IJsonSerializer jsonSerializer;
+        private readonly UnleashSettings settings;
         private readonly string path;
         private readonly bool throwOnFail;
         private readonly Dictionary<string, string> customHeaders;
 
-        public ToggleBootstrapUrlProvider(string path, HttpClient client, IJsonSerializer jsonSerializer, bool throwOnFail = false, Dictionary<string, string> customHeaders = null)
+        public ToggleBootstrapUrlProvider(string path, HttpClient client, UnleashSettings settings, bool throwOnFail = false, Dictionary<string, string> customHeaders = null)
         {
             this.path = path;
             this.client = client;
-            this.jsonSerializer = jsonSerializer;
+            this.settings = settings;
             this.throwOnFail = throwOnFail;
             this.customHeaders = customHeaders;
         }
@@ -64,7 +64,7 @@ namespace Unleash.Utilities
                     try
                     {
                         var togglesResponseStream = await response.Content.ReadAsStreamAsync();
-                        return jsonSerializer.Deserialize<ToggleCollection>(togglesResponseStream);
+                        return settings.JsonSerializer.Deserialize<ToggleCollection>(togglesResponseStream);
                     }
                     catch (Exception ex)
                     {

--- a/tests/Unleash.Tests/Utilities/ToggleBootstrapFileProvider_Tests.cs
+++ b/tests/Unleash.Tests/Utilities/ToggleBootstrapFileProvider_Tests.cs
@@ -27,7 +27,7 @@ namespace Unleash.Tests.Utilities
             // Arrange
             var fileSystem = new FileSystem(Encoding.UTF8);
             string toggleFileName = AppDataFile("unleash-repo-v1-missing.json");
-            var toggleFileProvider = new ToggleBootstrapFileProvider(toggleFileName, fileSystem, new JsonNetSerializer());
+            var toggleFileProvider = new ToggleBootstrapFileProvider(toggleFileName, fileSystem, new UnleashSettings() { FileSystem = fileSystem });
 
             // Act
             var emptyResult = toggleFileProvider.Read();
@@ -42,7 +42,7 @@ namespace Unleash.Tests.Utilities
             // Arrange
             var fileSystem = new FileSystem(Encoding.UTF8);
             string toggleFileName = AppDataFile("unleash-repo-v1.json");
-            var toggleFileProvider = new ToggleBootstrapFileProvider(toggleFileName, fileSystem, new JsonNetSerializer());
+            var toggleFileProvider = new ToggleBootstrapFileProvider(toggleFileName, fileSystem, new UnleashSettings() { FileSystem = fileSystem });
             var fileContent = fileSystem.ReadAllText(toggleFileName);
 
             // Act

--- a/tests/Unleash.Tests/Utilities/ToggleBootstrapFileProvider_Tests.cs
+++ b/tests/Unleash.Tests/Utilities/ToggleBootstrapFileProvider_Tests.cs
@@ -27,7 +27,7 @@ namespace Unleash.Tests.Utilities
             // Arrange
             var fileSystem = new FileSystem(Encoding.UTF8);
             string toggleFileName = AppDataFile("unleash-repo-v1-missing.json");
-            var toggleFileProvider = new ToggleBootstrapFileProvider(toggleFileName, new UnleashSettings() { FileSystem = fileSystem });
+            var toggleFileProvider = new ToggleBootstrapFileProvider(toggleFileName, new UnleashSettings() { FileSystem = fileSystem, JsonSerializer = new JsonNetSerializer() });
 
             // Act
             var emptyResult = toggleFileProvider.Read();
@@ -42,7 +42,7 @@ namespace Unleash.Tests.Utilities
             // Arrange
             var fileSystem = new FileSystem(Encoding.UTF8);
             string toggleFileName = AppDataFile("unleash-repo-v1.json");
-            var toggleFileProvider = new ToggleBootstrapFileProvider(toggleFileName, new UnleashSettings() { FileSystem = fileSystem });
+            var toggleFileProvider = new ToggleBootstrapFileProvider(toggleFileName, new UnleashSettings() { FileSystem = fileSystem, JsonSerializer = new JsonNetSerializer() });
             var fileContent = fileSystem.ReadAllText(toggleFileName);
 
             // Act

--- a/tests/Unleash.Tests/Utilities/ToggleBootstrapFileProvider_Tests.cs
+++ b/tests/Unleash.Tests/Utilities/ToggleBootstrapFileProvider_Tests.cs
@@ -51,5 +51,27 @@ namespace Unleash.Tests.Utilities
             // Assert
             result.Should().Equals(fileContent);
         }
+
+        [Test]
+        public void Returns_File_Content_When_Configured_Through_Settings_And_File_Exists()
+        {
+            // Arrange
+            var settings = new UnleashSettings()
+            {
+                JsonSerializer = new JsonNetSerializer(),
+            };
+            var toggleFileName = AppDataFile("unleash-repo-v1.json");
+            settings.UseBootstrapFileProvider(toggleFileName);
+            var fileSystem = new FileSystem(Encoding.UTF8);
+            settings.FileSystem = fileSystem;
+
+            var fileContent = fileSystem.ReadAllText(toggleFileName);
+
+            // Act
+            var result = settings.ToggleBootstrapProvider.Read();
+
+            // Assert
+            result.Should().Equals(fileContent);
+        }
     }
 }

--- a/tests/Unleash.Tests/Utilities/ToggleBootstrapFileProvider_Tests.cs
+++ b/tests/Unleash.Tests/Utilities/ToggleBootstrapFileProvider_Tests.cs
@@ -27,7 +27,7 @@ namespace Unleash.Tests.Utilities
             // Arrange
             var fileSystem = new FileSystem(Encoding.UTF8);
             string toggleFileName = AppDataFile("unleash-repo-v1-missing.json");
-            var toggleFileProvider = new ToggleBootstrapFileProvider(toggleFileName, fileSystem, new UnleashSettings() { FileSystem = fileSystem });
+            var toggleFileProvider = new ToggleBootstrapFileProvider(toggleFileName, new UnleashSettings() { FileSystem = fileSystem });
 
             // Act
             var emptyResult = toggleFileProvider.Read();
@@ -42,7 +42,7 @@ namespace Unleash.Tests.Utilities
             // Arrange
             var fileSystem = new FileSystem(Encoding.UTF8);
             string toggleFileName = AppDataFile("unleash-repo-v1.json");
-            var toggleFileProvider = new ToggleBootstrapFileProvider(toggleFileName, fileSystem, new UnleashSettings() { FileSystem = fileSystem });
+            var toggleFileProvider = new ToggleBootstrapFileProvider(toggleFileName, new UnleashSettings() { FileSystem = fileSystem });
             var fileContent = fileSystem.ReadAllText(toggleFileName);
 
             // Act

--- a/tests/Unleash.Tests/Utilities/ToggleBootstrapUrlProvider_Tests.cs
+++ b/tests/Unleash.Tests/Utilities/ToggleBootstrapUrlProvider_Tests.cs
@@ -29,7 +29,7 @@ namespace Unleash.Tests.Utilities
             };
             messageHandlerMock.Configure(path, returnMessage);
             var client = new HttpClient(messageHandlerMock);
-            var bootstrapUrlProvider = new ToggleBootstrapUrlProvider(path, client, new UnleashSettings());
+            var bootstrapUrlProvider = new ToggleBootstrapUrlProvider(path, client, new UnleashSettings() { JsonSerializer = new JsonNetSerializer() });
 
             // Act
             var responseContent = bootstrapUrlProvider.Read();
@@ -92,7 +92,7 @@ namespace Unleash.Tests.Utilities
             };
             messageHandlerMock.Configure(path, returnMessage);
             var client = new HttpClient(messageHandlerMock);
-            var bootstrapUrlProvider = new ToggleBootstrapUrlProvider(path, client, new UnleashSettings(), false, customHeaders);
+            var bootstrapUrlProvider = new ToggleBootstrapUrlProvider(path, client, new UnleashSettings() { JsonSerializer = new JsonNetSerializer() }, false, customHeaders);
 
             // Act
             var responseContent = bootstrapUrlProvider.Read();

--- a/tests/Unleash.Tests/Utilities/ToggleBootstrapUrlProvider_Tests.cs
+++ b/tests/Unleash.Tests/Utilities/ToggleBootstrapUrlProvider_Tests.cs
@@ -29,7 +29,7 @@ namespace Unleash.Tests.Utilities
             };
             messageHandlerMock.Configure(path, returnMessage);
             var client = new HttpClient(messageHandlerMock);
-            var bootstrapUrlProvider = new ToggleBootstrapUrlProvider(path, client, new JsonNetSerializer());
+            var bootstrapUrlProvider = new ToggleBootstrapUrlProvider(path, client, new UnleashSettings());
 
             // Act
             var responseContent = bootstrapUrlProvider.Read();
@@ -49,7 +49,7 @@ namespace Unleash.Tests.Utilities
             var returnMessage = new HttpResponseMessage(System.Net.HttpStatusCode.NotFound) { Content = new StringContent("") };
             messageHandlerMock.Configure(path, returnMessage);
             var client = new HttpClient(messageHandlerMock);
-            var bootstrapUrlProvider = new ToggleBootstrapUrlProvider(path, client, null);
+            var bootstrapUrlProvider = new ToggleBootstrapUrlProvider(path, client, new UnleashSettings());
 
             // Act
             var responseContent = bootstrapUrlProvider.Read();
@@ -69,7 +69,7 @@ namespace Unleash.Tests.Utilities
             var returnMessage = new HttpResponseMessage(System.Net.HttpStatusCode.NotFound) { Content = new StringContent("") };
             messageHandlerMock.Configure(path, returnMessage);
             var client = new HttpClient(messageHandlerMock);
-            var bootstrapUrlProvider = new ToggleBootstrapUrlProvider(path, client, null, true);
+            var bootstrapUrlProvider = new ToggleBootstrapUrlProvider(path, client, new UnleashSettings(), true);
 
             // Act, Assert
             Assert.Throws<FetchingToggleBootstrapUrlFailedException>(() => { var responseContent = bootstrapUrlProvider.Read(); });
@@ -92,7 +92,7 @@ namespace Unleash.Tests.Utilities
             };
             messageHandlerMock.Configure(path, returnMessage);
             var client = new HttpClient(messageHandlerMock);
-            var bootstrapUrlProvider = new ToggleBootstrapUrlProvider(path, client, new JsonNetSerializer(), false, customHeaders);
+            var bootstrapUrlProvider = new ToggleBootstrapUrlProvider(path, client, new UnleashSettings(), false, customHeaders);
 
             // Act
             var responseContent = bootstrapUrlProvider.Read();
@@ -118,7 +118,7 @@ namespace Unleash.Tests.Utilities
             };
             messageHandlerMock.Configure(path, returnMessage);
             var client = new HttpClient(messageHandlerMock);
-            var bootstrapUrlProvider = new ToggleBootstrapUrlProvider(path, client, new JsonNetSerializer());
+            var bootstrapUrlProvider = new ToggleBootstrapUrlProvider(path, client, new UnleashSettings());
 
             // Act
             var responseContent = bootstrapUrlProvider.Read();
@@ -142,7 +142,7 @@ namespace Unleash.Tests.Utilities
             };
             messageHandlerMock.Configure(path, returnMessage);
             var client = new HttpClient(messageHandlerMock);
-            var bootstrapUrlProvider = new ToggleBootstrapUrlProvider(path, client, new JsonNetSerializer(), true);
+            var bootstrapUrlProvider = new ToggleBootstrapUrlProvider(path, client, new UnleashSettings(), true);
 
             // Act, Assert
             Assert.Throws<UnleashException>(() => { var responseContent = bootstrapUrlProvider.Read(); });


### PR DESCRIPTION
# Description

Take UnleashSettings in Bootstrap providers as argument to use as source for services instead of individual arguments that potentially are not created yet

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Created new Unit tests
- [x] Updated and ran old unit tests

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules