### PR TITLE
fix: count variants

### DIFF
--- a/src/Unleash/Metrics/ToggleCount.cs
+++ b/src/Unleash/Metrics/ToggleCount.cs
@@ -27,7 +27,7 @@ namespace Unleash.Metrics
 
         public void Register(string variantName)
         {
-            variants.AddOrUpdate(variantName, 1, (k, v) => Interlocked.Increment(ref v));
+            variants.AddOrUpdate(variantName, 1, (k, v) => v + 1);
         }
 
         /// <summary>

--- a/src/Unleash/Metrics/ToggleCount.cs
+++ b/src/Unleash/Metrics/ToggleCount.cs
@@ -27,8 +27,7 @@ namespace Unleash.Metrics
 
         public void Register(string variantName)
         {
-            var current = variants.GetOrAdd(variantName, s => new long());
-            Interlocked.Increment(ref current);
+            variants.AddOrUpdate(variantName, 1, (k, v) => Interlocked.Increment(ref v));
         }
 
         /// <summary>


### PR DESCRIPTION
This PR adds a test and a fix for an issue we had when counting variants in the `ToggleCount` class. As reported in #138, the old way we counted didn't work.

I've kept the same testing style as applied in the other metrics bucket tests. Testing 100000 counts seems a little excessive, but it should at least prove that it works. Happy to change it if you think it's too much. 

Thanks to @nhathongly for the fix.

Fixes #138

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Unit tests

**Test Configuration**:
* Firmware version: (I don't know. What do you want here?)
* Hardware: MacOS M1 chip
* Toolchain: dotnet version 7.0.302
* SDK: from `chore/make-dotnet-compatible` branch

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules