### PR TITLE
chore: change context defaults to null - fixes flexiblestrat

### DIFF
--- a/src/Unleash/DefaultUnleashContextProvider.cs
+++ b/src/Unleash/DefaultUnleashContextProvider.cs
@@ -8,9 +8,6 @@ namespace Unleash
         {
             Context = context ?? new UnleashContext
             {
-                UserId = string.Empty,
-                SessionId = string.Empty,
-                RemoteAddress = string.Empty,
                 Properties = new Dictionary<string, string>(0),
             };
         }

--- a/tests/Unleash.Tests/DefaultUnleashTests.cs
+++ b/tests/Unleash.Tests/DefaultUnleashTests.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Net;
 using System.Net.Http.Headers;
 using System.Text;
+using System.Threading;
 using Unleash.Internal;
 using Unleash.Scheduling;
 using Unleash.Strategies;

--- a/tests/Unleash.Tests/DefaultUnleashTests.cs
+++ b/tests/Unleash.Tests/DefaultUnleashTests.cs
@@ -1,7 +1,16 @@
-﻿using FluentAssertions;
+﻿using FakeItEasy;
+using FluentAssertions;
 using NUnit.Framework;
 using System;
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text;
+using Unleash.Internal;
+using Unleash.Scheduling;
+using Unleash.Strategies;
 using Unleash.Tests.Mock;
+using Unleash.Variants;
+using static Unleash.Tests.Specifications.TestFactory;
 
 namespace Unleash.Tests
 {
@@ -41,6 +50,114 @@ namespace Unleash.Tests
 
             // Assert
             factory.CreateHttpClientInstanceCalled.Should().BeTrue();
+        }
+
+        [Test]
+        public void IsEnabled_Flexible_Strategy_Test()
+        {
+            // Arrange
+            var appname = "testapp";
+            var strategy = new ActivationStrategy("flexibleRollout", new Dictionary<string, string>() { { "rollout", "100" } }, new List<Constraint>() { });
+            var toggles = new List<FeatureToggle>()
+            {
+                new FeatureToggle("test_toggle", "experimental", true, false, new List<ActivationStrategy>() { strategy })
+            };
+
+
+            var state = new ToggleCollection(toggles);
+            state.Version = 2;
+            var unleash = CreateUnleash(appname, state);
+
+            // Act
+            var result = unleash.IsEnabled("test_toggle");
+
+            // Assert
+            result.Should().BeTrue();
+        }
+
+        [Test]
+        public void IsEnabled_Gradual_Rollout_Random_Strategy_Test()
+        {
+            // Arrange
+            var appname = "testapp";
+            var strategy = new ActivationStrategy("gradualRolloutRandom", new Dictionary<string, string>() { { "percentage", "100" } }, new List<Constraint>() { });
+            var toggles = new List<FeatureToggle>()
+            {
+                new FeatureToggle("test_toggle", "experimental", true, false, new List<ActivationStrategy>() { strategy })
+            };
+
+
+            var state = new ToggleCollection(toggles);
+            state.Version = 2;
+            var unleash = CreateUnleash(appname, state);
+
+            // Act
+            var result = unleash.IsEnabled("test_toggle");
+
+            // Assert
+            result.Should().BeTrue();
+        }
+
+        [Test]
+        public void IsEnabled_Gradual_Rollout_UserId_Strategy_Test()
+        {
+            // Arrange
+            var appname = "testapp";
+            var strategy = new ActivationStrategy("gradualRolloutUserId", new Dictionary<string, string>() { { "percentage", "100" } }, new List<Constraint>() { });
+            var toggles = new List<FeatureToggle>()
+            {
+                new FeatureToggle("test_toggle", "experimental", true, false, new List<ActivationStrategy>() { strategy })
+            };
+
+
+            var state = new ToggleCollection(toggles);
+            state.Version = 2;
+            var unleash = CreateUnleash(appname, state);
+
+            // Act
+            var result = unleash.IsEnabled("test_toggle");
+
+            // Assert
+            result.Should().BeFalse();
+        }
+
+        public static IUnleash CreateUnleash(string name, ToggleCollection state)
+        {
+            var fakeHttpClientFactory = A.Fake<IHttpClientFactory>();
+            var fakeHttpMessageHandler = new TestHttpMessageHandler();
+            var httpClient = new HttpClient(fakeHttpMessageHandler) { BaseAddress = new Uri("http://localhost") };
+            var fakeScheduler = A.Fake<IUnleashScheduledTaskManager>();
+            var fakeFileSystem = new MockFileSystem();
+            var toggleState = Newtonsoft.Json.JsonConvert.SerializeObject(state);
+
+            A.CallTo(() => fakeHttpClientFactory.Create(A<Uri>._)).Returns(httpClient);
+            A.CallTo(() => fakeScheduler.Configure(A<IEnumerable<IUnleashScheduledTask>>._, A<CancellationToken>._)).Invokes(action =>
+            {
+                var task = ((IEnumerable<IUnleashScheduledTask>)action.Arguments[0]).First();
+                task.ExecuteAsync((CancellationToken)action.Arguments[1]).Wait();
+            });
+
+            fakeHttpMessageHandler.Response = new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent(toggleState, Encoding.UTF8, "application/json"),
+                Headers =
+                {
+                    ETag = new EntityTagHeaderValue("\"123\"")
+                }
+            };
+
+            var settings = new UnleashSettings
+            {
+                AppName = name,
+                HttpClientFactory = fakeHttpClientFactory,
+                ScheduledTaskManager = fakeScheduler,
+                FileSystem = fakeFileSystem
+            };
+
+            var unleash = new DefaultUnleash(settings);
+
+            return unleash;
         }
     }
 }

--- a/tests/Unleash.Tests/DefaultUnleashTests.cs
+++ b/tests/Unleash.Tests/DefaultUnleashTests.cs
@@ -4,6 +4,7 @@ using NUnit.Framework;
 using System;
 using System.Collections.Generic;
 using System.Net;
+using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
 using System.Threading;

--- a/tests/Unleash.Tests/DefaultUnleashTests.cs
+++ b/tests/Unleash.Tests/DefaultUnleashTests.cs
@@ -8,6 +8,7 @@ using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
 using System.Threading;
+using System.Linq;
 using Unleash.Internal;
 using Unleash.Scheduling;
 using Unleash.Strategies;

--- a/tests/Unleash.Tests/DefaultUnleashTests.cs
+++ b/tests/Unleash.Tests/DefaultUnleashTests.cs
@@ -2,6 +2,7 @@
 using FluentAssertions;
 using NUnit.Framework;
 using System;
+using System.Collections.Generic;
 using System.Net;
 using System.Net.Http.Headers;
 using System.Text;


### PR DESCRIPTION
# Description

This fixes an issue with Flexible rollout strategy - stickiness would be resolved to an empty (non null) string instead of defaulting to random number when context isn't provided

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] Created new unit tests
- [x] Ran existing tests

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules