### PR TITLE
Added support for toggle update event

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,9 +170,9 @@ Refer to the [Unleash context](#unleash-context) section for more information ab
 ## Handling events
 
 Currently supported events:
-- [Impression data events](https://docs.getunleash.io/advanced/impression-data#impression-event-data)
-- Error events
-- Toggles updated event
+-  [Impression data events](https://docs.getunleash.io/advanced/impression-data#impression-event-data)
+-  Error events
+-  Toggles updated event
 
 ```csharp
 

--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ Refer to the [Unleash context](#unleash-context) section for more information ab
 Currently supported events:
 - [Impression data events](https://docs.getunleash.io/advanced/impression-data#impression-event-data)
 - Error events
+- Toggles updated event
 
 ```csharp
 
@@ -187,6 +188,7 @@ unleash.ConfigureEvents(cfg =>
 {
     cfg.ImpressionEvent = evt => { Console.WriteLine($"{evt.FeatureName}: {evt.Enabled}"); };
     cfg.ErrorEvent = evt => { /* Handling code here */ Console.WriteLine($"{evt.ErrorType} occured."); };
+    cfg.TogglesUpdatedEvent = evt => { /* Handling code here */ Console.WriteLine($"Toggles updated on: {evt.UpdatedOn}"); };
 });
 
 ```

--- a/src/Unleash/Internal/EventCallbackConfig.cs
+++ b/src/Unleash/Internal/EventCallbackConfig.cs
@@ -7,6 +7,7 @@ namespace Unleash.Internal
     {
         public Action<ImpressionEvent> ImpressionEvent { get; set; }
         public Action<ErrorEvent> ErrorEvent { get; set; }
+        public Action<TogglesUpdatedEvent> TogglesUpdatedEvent { get; set; }
 
         public void RaiseError(ErrorEvent evt)
         {
@@ -15,5 +16,14 @@ namespace Unleash.Internal
                 ErrorEvent(evt);
             }
         }
+
+        public void RaiseTogglesUpdated(TogglesUpdatedEvent evt)
+        {
+            if (TogglesUpdatedEvent != null)
+            {
+                TogglesUpdatedEvent(evt);
+            }
+        }
+
     }
 }

--- a/src/Unleash/Internal/TogglesUpdatedEvent.cs
+++ b/src/Unleash/Internal/TogglesUpdatedEvent.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Unleash.Internal
+{
+    public class TogglesUpdatedEvent
+    {
+        public DateTime UpdatedOn { get; set; }
+    }
+}

--- a/src/Unleash/Scheduling/FetchFeatureTogglesTask.cs
+++ b/src/Unleash/Scheduling/FetchFeatureTogglesTask.cs
@@ -64,7 +64,7 @@ namespace Unleash.Scheduling
             }
             else
             {
-                eventConfig?.RaiseTogglesUpdated(new TogglesUpdatedEvent() { UpdatedOn = DateTime.UtcNow });
+                eventConfig?.RaiseTogglesUpdated(new TogglesUpdatedEvent { UpdatedOn = DateTime.UtcNow });
             }
 
             if (string.IsNullOrEmpty(result.Etag))

--- a/src/Unleash/Scheduling/FetchFeatureTogglesTask.cs
+++ b/src/Unleash/Scheduling/FetchFeatureTogglesTask.cs
@@ -59,7 +59,13 @@ namespace Unleash.Scheduling
             }
 
             if (!result.HasChanged)
+            {
                 return;
+            }
+            else
+            {
+                eventConfig?.RaiseTogglesUpdated(new TogglesUpdatedEvent() { UpdatedOn = DateTime.UtcNow });
+            }
 
             if (string.IsNullOrEmpty(result.Etag))
                 return;

--- a/tests/Unleash.Tests/Internal/TogglesUpdatedEvent_Tests.cs
+++ b/tests/Unleash.Tests/Internal/TogglesUpdatedEvent_Tests.cs
@@ -18,14 +18,14 @@ namespace Unleash.Tests.Internal
         {
             // Arrange
             TogglesUpdatedEvent callbackEvent = null;
-            var callbackConfig = new EventCallbackConfig()
+            var callbackConfig = new EventCallbackConfig
             {
                 TogglesUpdatedEvent = evt => { callbackEvent = evt; }
             };
 
             var fakeApiClient = A.Fake<IUnleashApiClient>();
             A.CallTo(() => fakeApiClient.FetchToggles(A<string>._, A<CancellationToken>._))
-                .Returns(Task.FromResult(new FetchTogglesResult() { HasChanged = true, ToggleCollection = new ToggleCollection(), Etag = "one" }));
+                .Returns(Task.FromResult(new FetchTogglesResult { HasChanged = true, ToggleCollection = new ToggleCollection(), Etag = "one" }));
 
             var collection = new ThreadSafeToggleCollection();
             var serializer = new DynamicNewtonsoftJsonSerializer();
@@ -47,14 +47,14 @@ namespace Unleash.Tests.Internal
         {
             // Arrange
             TogglesUpdatedEvent callbackEvent = null;
-            var callbackConfig = new EventCallbackConfig()
+            var callbackConfig = new EventCallbackConfig
             {
                 TogglesUpdatedEvent = evt => { callbackEvent = evt; }
             };
 
             var fakeApiClient = A.Fake<IUnleashApiClient>();
             A.CallTo(() => fakeApiClient.FetchToggles(A<string>._, A<CancellationToken>._))
-                .Returns(Task.FromResult(new FetchTogglesResult() { HasChanged = false, ToggleCollection = new ToggleCollection(), Etag = "one" }));
+                .Returns(Task.FromResult(new FetchTogglesResult { HasChanged = false, ToggleCollection = new ToggleCollection(), Etag = "one" }));
 
             var collection = new ThreadSafeToggleCollection();
             var serializer = new DynamicNewtonsoftJsonSerializer();

--- a/tests/Unleash.Tests/Internal/TogglesUpdatedEvent_Tests.cs
+++ b/tests/Unleash.Tests/Internal/TogglesUpdatedEvent_Tests.cs
@@ -1,0 +1,74 @@
+﻿using FakeItEasy;
+using FluentAssertions;
+using NUnit.Framework;
+using System.Threading;
+using System.Threading.Tasks;
+using Unleash.Communication;
+using Unleash.Internal;
+using Unleash.Scheduling;
+using Unleash.Serialization;
+using Unleash.Tests.Mock;
+
+namespace Unleash.Tests.Internal
+{
+    public class TogglesUpdatedEvent_Tests
+    {
+        [Test]
+        public void TogglesUpdated_Event_Gets_Called_For_HasChanged_True()
+        {
+            // Arrange
+            TogglesUpdatedEvent callbackEvent = null;
+            var callbackConfig = new EventCallbackConfig()
+            {
+                TogglesUpdatedEvent = evt => { callbackEvent = evt; }
+            };
+
+            var fakeApiClient = A.Fake<IUnleashApiClient>();
+            A.CallTo(() => fakeApiClient.FetchToggles(A<string>._, A<CancellationToken>._))
+                .Returns(Task.FromResult(new FetchTogglesResult() { HasChanged = true, ToggleCollection = new ToggleCollection(), Etag = "one" }));
+
+            var collection = new ThreadSafeToggleCollection();
+            var serializer = new DynamicNewtonsoftJsonSerializer();
+            serializer.TryLoad();
+
+            var filesystem = new MockFileSystem();
+            var tokenSource = new CancellationTokenSource();
+            var task = new FetchFeatureTogglesTask(fakeApiClient, collection, serializer, filesystem, callbackConfig, "togglefile.txt", "etagfile.txt");
+
+            // Act
+            Task.WaitAll(task.ExecuteAsync(tokenSource.Token));
+
+            // Assert
+            callbackEvent.Should().NotBeNull();
+        }
+
+        [Test]
+        public void TogglesUpdated_Event_Does_Not_Get_Called_For_HasChanged_False()
+        {
+            // Arrange
+            TogglesUpdatedEvent callbackEvent = null;
+            var callbackConfig = new EventCallbackConfig()
+            {
+                TogglesUpdatedEvent = evt => { callbackEvent = evt; }
+            };
+
+            var fakeApiClient = A.Fake<IUnleashApiClient>();
+            A.CallTo(() => fakeApiClient.FetchToggles(A<string>._, A<CancellationToken>._))
+                .Returns(Task.FromResult(new FetchTogglesResult() { HasChanged = false, ToggleCollection = new ToggleCollection(), Etag = "one" }));
+
+            var collection = new ThreadSafeToggleCollection();
+            var serializer = new DynamicNewtonsoftJsonSerializer();
+            serializer.TryLoad();
+
+            var filesystem = new MockFileSystem();
+            var tokenSource = new CancellationTokenSource();
+            var task = new FetchFeatureTogglesTask(fakeApiClient, collection, serializer, filesystem, callbackConfig, "togglefile.txt", "etagfile.txt");
+
+            // Act
+            Task.WaitAll(task.ExecuteAsync(tokenSource.Token));
+
+            // Assert
+            callbackEvent.Should().BeNull();
+        }
+    }
+}

--- a/tests/Unleash.Tests/Unleash.Tests.csproj
+++ b/tests/Unleash.Tests/Unleash.Tests.csproj
@@ -84,6 +84,7 @@
     <Compile Include="Internal\CachedFilesLoaderTestBase.cs" />
     <Compile Include="Internal\CachedFilesLoader_Backup_And_Etag_Tests.cs" />
     <Compile Include="Internal\CachedFilesLoader_Bootstrap_Tests.cs" />
+    <Compile Include="Internal\TogglesUpdatedEvent_Tests.cs" />
     <Compile Include="Internal\ErrorEvents_Tests.cs" />
     <Compile Include="Internal\ImpressionData_Tests.cs" />
     <Compile Include="IOTests.cs" />


### PR DESCRIPTION
# Description

Added new `TogglesUpdatedEvent` that is raised by `FetchFeatureTogglesTask` when there are changes (`result.HasChanged`). This is done to allow dotnet client applications to take any actions, as needed, in response to toggle updates.

Fixes #149

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Unit tests added. See `unleash-client-dotnet\tests\Unleash.Tests\Internal\TogglesUpdatedEvent_Tests.cs`
- [x] I also tested this by adding a project reference for `unleash-client-dotnet\src\Unleash\Unleash.csproj` to our dotnet application to verify that the event was raised and handled by our application.

**Test Configuration**:
* IDE: Visual Studio Professional 2022 (64-bit) Version 17.4.4
* Client application that uses `unleash-client-dotnet` targets **net 6.0**

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules