### PR TITLE
fix: rethrow exc so synchronous works as intended

### DIFF
--- a/src/Unleash/Scheduling/FetchFeatureTogglesTask.cs
+++ b/src/Unleash/Scheduling/FetchFeatureTogglesTask.cs
@@ -55,7 +55,7 @@ namespace Unleash.Scheduling
             {
                 Logger.ErrorException($"UNLEASH: Unhandled exception when fetching toggles.", ex);
                 eventConfig?.RaiseError(new ErrorEvent() { ErrorType = ErrorType.Client, Error = ex });
-                return;
+                throw new UnleashException("Exception while fetching from API", ex);
             }
 
             if (!result.HasChanged)


### PR DESCRIPTION
# Description

HttpRequestExceptions were not propagating up during synchronous initialization.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Testing locally with testapp

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules