### PR TITLE
fix: impression data should now contain static appName even if its not set

### DIFF
--- a/src/Unleash/DefaultUnleash.cs
+++ b/src/Unleash/DefaultUnleash.cs
@@ -39,7 +39,7 @@ namespace Unleash
         internal readonly UnleashServices services;
 
         ///// <summary>
-        ///// Initializes a new instance of Unleash client with a set of default strategies. 
+        ///// Initializes a new instance of Unleash client with a set of default strategies.
         ///// </summary>
         ///// <param name="config">Unleash settings</param>
         ///// <param name="strategies">Additional custom strategies.</param>
@@ -106,6 +106,7 @@ namespace Unleash
         private bool CheckIsEnabled(string toggleName, UnleashContext context, bool defaultSetting)
         {
             var featureToggle = GetToggle(toggleName);
+            var enhancedContext = context.ApplyStaticFields(settings);
 
             bool enabled = false;
             if (featureToggle == null)
@@ -123,13 +124,12 @@ namespace Unleash
             }
             else
             {
-                var enhancedContext = context.ApplyStaticFields(settings);
                 enabled = featureToggle.Strategies.Any(s => GetStrategyOrUnknown(s.Name).IsEnabled(s.Parameters, enhancedContext, ResolveConstraints(s).Union(s.Constraints)));
             }
 
             RegisterCount(toggleName, enabled);
 
-            if (featureToggle?.ImpressionData ?? false) EmitImpressionEvent("isEnabled", context, enabled, featureToggle.Name);
+            if (featureToggle?.ImpressionData ?? false) EmitImpressionEvent("isEnabled", enhancedContext, enabled, featureToggle.Name);
 
             return enabled;
         }
@@ -152,8 +152,9 @@ namespace Unleash
             var variant = enabled ? VariantUtils.SelectVariant(toggle, context, defaultValue) : defaultValue;
 
             RegisterVariant(toggleName, variant);
+            var enhancedContext = context.ApplyStaticFields(settings);
 
-            if (toggle?.ImpressionData ?? false) EmitImpressionEvent("getVariant", context, enabled, toggle.Name, variant.Name);
+            if (toggle?.ImpressionData ?? false) EmitImpressionEvent("getVariant", enhancedContext, enabled, toggle.Name, variant.Name);
 
             return variant;
         }
@@ -220,8 +221,8 @@ namespace Unleash
 
         private IStrategy GetStrategyOrUnknown(string strategy)
         {
-            return strategyMap.ContainsKey(strategy) 
-                ? strategyMap[strategy] 
+            return strategyMap.ContainsKey(strategy)
+                ? strategyMap[strategy]
                 : UnknownStrategy;
         }
 
@@ -290,7 +291,7 @@ namespace Unleash
 
         public void Dispose()
         {
-            services?.Dispose(); 
+            services?.Dispose();
         }
     }
 }

--- a/tests/Unleash.Tests/Internal/ImpressionData_Tests.cs
+++ b/tests/Unleash.Tests/Internal/ImpressionData_Tests.cs
@@ -49,6 +49,7 @@ namespace Unleash.Tests.Internal
             result.Should().BeTrue();
             callbackEvent.Should().NotBeNull();
             callbackEvent.Enabled.Should().BeTrue();
+            callbackEvent.Context.AppName.Should().Be(appname);
             callbackEvent.Variant.Should().BeNull();
         }
 
@@ -164,6 +165,7 @@ namespace Unleash.Tests.Internal
             callbackEvent.Should().NotBeNull();
             callbackEvent.Enabled.Should().BeTrue();
             callbackEvent.Variant.Should().Be("blue");
+            callbackEvent.Context.AppName.Should().Be(appname);
         }
 
         [Test]


### PR DESCRIPTION
This patches an issue in the SDK where the appName was not being set correctly when applying impression data. This was caused by passing the base context, rather than the enriched context 