### PR TITLE
feat: clean up unleash settings on sync-init error

### DIFF
--- a/tests/Unleash.Tests/ClientFactory/SyncStartupUnitTest.cs
+++ b/tests/Unleash.Tests/ClientFactory/SyncStartupUnitTest.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Unleash.ClientFactory;
 using FluentAssertions;
 using System;
+using Unleash;
 
 namespace Unleash.Tests.ClientFactory
 {
@@ -51,7 +52,7 @@ namespace Unleash.Tests.ClientFactory
             A.CallTo(() => mockApiClient.FetchToggles(A<string>.Ignored, A<CancellationToken>.Ignored))
                 .Throws<Exception>();
 
-            Assert.ThrowsAsync<Exception>(async () => await unleashFactory.CreateClientAsync(settings, synchronousInitialization: true));
+            Assert.ThrowsAsync<UnleashException>(async () => await unleashFactory.CreateClientAsync(settings, synchronousInitialization: true));
         }
 
         [Test(Description = "Immediate initialization: Should bubble up async fetch errors")]
@@ -61,7 +62,7 @@ namespace Unleash.Tests.ClientFactory
             A.CallTo(() => mockApiClient.FetchToggles(A<string>.Ignored, A<CancellationToken>.Ignored))
                 .ThrowsAsync(new Exception());
 
-            Assert.ThrowsAsync<Exception>(async () => await unleashFactory.CreateClientAsync(settings, synchronousInitialization: true));
+            Assert.ThrowsAsync<UnleashException>(async () => await unleashFactory.CreateClientAsync(settings, synchronousInitialization: true));
         }
 
         [Test(Description = "Delayed initialization: Should only fetch toggles once")]


### PR DESCRIPTION
# Description

Cleans up and adds a new scheduler on UnleashSettings if the current instance of it is an instance of our own `SystemTimerScheduledTaskManager`

Fixes # (issue)

#152 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Planning on testing this with a sample app to repro the issue

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules