### PR TITLE
Raise TogglesUpdatedEvent after toggle collection is updated

### DIFF
--- a/src/Unleash/Scheduling/FetchFeatureTogglesTask.cs
+++ b/src/Unleash/Scheduling/FetchFeatureTogglesTask.cs
@@ -62,10 +62,6 @@ namespace Unleash.Scheduling
             {
                 return;
             }
-            else
-            {
-                eventConfig?.RaiseTogglesUpdated(new TogglesUpdatedEvent { UpdatedOn = DateTime.UtcNow });
-            }
 
             if (string.IsNullOrEmpty(result.Etag))
                 return;
@@ -74,6 +70,9 @@ namespace Unleash.Scheduling
                 return;
 
             toggleCollection.Instance = result.ToggleCollection;
+
+            // now that the toggle collection has been updated, raise the toggles updated event if configured
+            eventConfig?.RaiseTogglesUpdated(new TogglesUpdatedEvent { UpdatedOn = DateTime.UtcNow });
 
             try
             {

--- a/tests/Unleash.Tests/Internal/TogglesUpdatedEvent_Tests.cs
+++ b/tests/Unleash.Tests/Internal/TogglesUpdatedEvent_Tests.cs
@@ -1,6 +1,8 @@
 ﻿using FakeItEasy;
 using FluentAssertions;
 using NUnit.Framework;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Unleash.Communication;
@@ -69,6 +71,43 @@ namespace Unleash.Tests.Internal
 
             // Assert
             callbackEvent.Should().BeNull();
+        }
+
+        [Test]
+        public void TogglesUpdated_Event_Is_Raised_After_ToggleCollection_Is_Updated()
+        {
+            // Arrange
+            var fetchResultToggleCollection = new ToggleCollection();
+            fetchResultToggleCollection.Features.Add(new FeatureToggle("toggle-1", "operational", true, false, new List<ActivationStrategy>())); // after toggles are fetched, the toggle is enabled
+
+            var toggleCollection = new ThreadSafeToggleCollection();
+            toggleCollection.Instance = new ToggleCollection();
+            toggleCollection.Instance.Features.Add(new FeatureToggle("toggle-1", "operational", false, false, new List<ActivationStrategy>())); // initially, the toggle is NOT enabled
+
+            var toggleIsEnabledResultAfterEvent = false;
+            var callbackConfig = new EventCallbackConfig
+            {
+                // when toggles updated event is raised (after the fetch), check toggle collection to see if toggle is enabled
+                TogglesUpdatedEvent = evt => { toggleIsEnabledResultAfterEvent = toggleCollection.Instance.Features.ElementAt(0).Enabled; }
+            };
+
+            var fakeApiClient = A.Fake<IUnleashApiClient>();
+            A.CallTo(() => fakeApiClient.FetchToggles(A<string>._, A<CancellationToken>._))
+                .Returns(Task.FromResult(new FetchTogglesResult { HasChanged = true, ToggleCollection = fetchResultToggleCollection, Etag = "one" }));
+
+            var serializer = new DynamicNewtonsoftJsonSerializer();
+            serializer.TryLoad();
+
+            var filesystem = new MockFileSystem();
+            var tokenSource = new CancellationTokenSource();
+            var task = new FetchFeatureTogglesTask(fakeApiClient, toggleCollection, serializer, filesystem, callbackConfig, "togglefile.txt", "etagfile.txt");
+
+            // Act
+            Task.WaitAll(task.ExecuteAsync(tokenSource.Token));
+
+            // Assert
+            toggleCollection.Instance.Features.ElementAt(0).Enabled.Should().BeTrue(); // verify that toggle collection has been updated after fetch and shows that toggle is enabled
+            toggleIsEnabledResultAfterEvent.Should().BeTrue(); // verify that toggles updated event handler got the correct result for the updated toggle state (should now be enabled)
         }
     }
 }


### PR DESCRIPTION
# Description

Raise the `TogglesUpdatedEvent` AFTER the toggles collection is updated in `FetchFeatureTogglesTask`. This will allow clients that provide an event handler to be able to obtain the current toggle state rather than the "old" state.

Fixes # ([160](https://github.com/Unleash/unleash-client-dotnet/issues/160))

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Tested this by adding a project reference for `unleash-client-dotnet\src\Unleash\Unleash.csproj` to our dotnet application to verify that the event was raised and our application could see the current toggle state.

**Test Configuration**:
* IDE: Visual Studio Professional 2022 (64-bit) Version 17.4.4
* Client application that uses unleash-client-dotnet targets net 6.0

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules