### PR TITLE
docs: add best practises article link to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -538,3 +538,7 @@ The Unleash team have made a separate project which runs unleash server inside d
 Visual Studio 2017 / Code
 
 Cakebuild
+
+### Other information
+
+- Check out our guide for more information on how to build and scale [feature flag](https://docs.getunleash.io/topics/feature-flags/feature-flag-best-practices) systems


### PR DESCRIPTION
# Description

Adds a link to our best practises article to the bottom of the readme 

Fixes # (issue)

## Type of change

- [x] Documentation update
