### PR TITLE
fix: add a seed to variant utils murmur hashing to fix variant distri…

### DIFF
--- a/src/Unleash/Strategies/FlexibleRolloutStrategy.cs
+++ b/src/Unleash/Strategies/FlexibleRolloutStrategy.cs
@@ -42,7 +42,7 @@ namespace Unleash.Strategies
 
             if (!string.IsNullOrEmpty(stickinessId))
             {
-                var normalizedUserId = StrategyUtils.GetNormalizedNumber(stickinessId, groupId);
+                var normalizedUserId = StrategyUtils.GetNormalizedNumber(stickinessId, groupId, 0);
                 return percentage > 0 && normalizedUserId <= percentage;
             }
             else

--- a/src/Unleash/Strategies/GradualRolloutSessionIdStrategy.cs
+++ b/src/Unleash/Strategies/GradualRolloutSessionIdStrategy.cs
@@ -35,7 +35,7 @@ namespace Unleash.Strategies
             var percentage = StrategyUtils.GetPercentage(percentageString);
             var groupId = parameters[GroupId] ?? string.Empty;
 
-            var normalizedSessionId = StrategyUtils.GetNormalizedNumber(sessionId, groupId);
+            var normalizedSessionId = StrategyUtils.GetNormalizedNumber(sessionId, groupId, 0);
 
             return percentage > 0 && normalizedSessionId <= percentage;
         }

--- a/src/Unleash/Strategies/GradualRolloutUserIdStrategy.cs
+++ b/src/Unleash/Strategies/GradualRolloutUserIdStrategy.cs
@@ -35,7 +35,7 @@ namespace Unleash.Strategies
             var percentage = StrategyUtils.GetPercentage(percentageString);
             var groupId = parameters[GroupIdConst] ?? string.Empty;
 
-            var normalizedUserId = StrategyUtils.GetNormalizedNumber(userId, groupId);
+            var normalizedUserId = StrategyUtils.GetNormalizedNumber(userId, groupId, 0);
 
             return percentage > 0 && normalizedUserId <= percentage;
         }

--- a/src/Unleash/Strategies/StrategyUtils.cs
+++ b/src/Unleash/Strategies/StrategyUtils.cs
@@ -12,14 +12,14 @@ namespace Unleash.Strategies
         /// <summary>
         /// Takes to string inputs concat them, produce a hashCode and return a normalized value between 0 and 100;
         /// </summary>
-        public static int GetNormalizedNumber(string identifier, string groupId, int normalizer = 100)
+        public static int GetNormalizedNumber(string identifier, string groupId, uint randomSeed, int normalizer = 100)
         {
             const int one = 1;
             const string separator = ":";
 
             byte[] bytes = Encoding.UTF8.GetBytes(string.Concat(groupId, separator, identifier));
 
-            using (var algorithm = MurmurHash.Create32())
+            using (var algorithm = MurmurHash.Create32(randomSeed))
             {
                 var hash = algorithm.ComputeHash(bytes);
                 var value = BitConverter.ToUInt32(hash, 0);

--- a/src/Unleash/Variants/VariantUtils.cs
+++ b/src/Unleash/Variants/VariantUtils.cs
@@ -8,6 +8,8 @@ namespace Unleash.Variants
 {
     internal class VariantUtils
     {
+        public static readonly uint VARIANT_NORMALIZATION_SEED = 86028157;
+
         public static Variant SelectVariant(string groupId, UnleashContext context, List<VariantDefinition> variantDefinitions)
         {
             var totalWeight = variantDefinitions.Sum(v => v.Weight);
@@ -23,7 +25,7 @@ namespace Unleash.Variants
             }
 
             var stickiness = variantDefinitions[0].Stickiness ?? "default";
-            var target = StrategyUtils.GetNormalizedNumber(GetIdentifier(context, stickiness), groupId, totalWeight);
+            var target = StrategyUtils.GetNormalizedNumber(GetIdentifier(context, stickiness), groupId, VARIANT_NORMALIZATION_SEED, totalWeight);
 
             var counter = 0;
             foreach (var variantDefinition in variantDefinitions)

--- a/tests/Unleash.Tests/Integration/ClientSpecificationTests.cs
+++ b/tests/Unleash.Tests/Integration/ClientSpecificationTests.cs
@@ -38,7 +38,7 @@ namespace Unleash.Tests.Specifications
 
             using (var client = new HttpClient())
             {
-                var csTestsVersion = "v4.5.2";
+                var csTestsVersion = "v5.0.2";
                 var indexPath = $"https://raw.githubusercontent.com/Unleash/client-specification/{csTestsVersion}/specifications/";
                 var indexResponse = client.GetStringAsync(indexPath + "index.json").Result;
                 var indexFilePath = Path.Combine(specificationsPath, "index.json");

--- a/tests/Unleash.Tests/Strategy/GradualRolloutSessionIdStrategyTest.cs
+++ b/tests/Unleash.Tests/Strategy/GradualRolloutSessionIdStrategyTest.cs
@@ -100,7 +100,7 @@ namespace Unleash.Tests.Strategy
         {
             string sessionId = "1574576830";
             string groupId = "";
-            int minimumPercentage = StrategyUtils.GetNormalizedNumber(sessionId, groupId);
+            int minimumPercentage = StrategyUtils.GetNormalizedNumber(sessionId, groupId, 0);
 
             var context = UnleashContext.New().SessionId(sessionId).Build();
 

--- a/tests/Unleash.Tests/Strategy/GradualRolloutUserIdStrategyTest.cs
+++ b/tests/Unleash.Tests/Strategy/GradualRolloutUserIdStrategyTest.cs
@@ -99,7 +99,7 @@ namespace Unleash.Tests.Strategy
         {
             var userId = "1574576830";
             var groupId = "";
-            var minimumPercentage = StrategyUtils.GetNormalizedNumber(userId, groupId);
+            var minimumPercentage = StrategyUtils.GetNormalizedNumber(userId, groupId, 0);
 
             var context = UnleashContext.New().UserId(userId).Build();
             var gradualRolloutStrategy = new GradualRolloutUserIdStrategy();

--- a/tests/Unleash.Tests/Strategy/StrategyUtilsTests.cs
+++ b/tests/Unleash.Tests/Strategy/StrategyUtilsTests.cs
@@ -39,19 +39,19 @@ namespace Unleash.Tests.Strategy
         public void GetNormalizedNumber_Variants()
         {
             // Normal cases
-            StrategyUtils.GetNormalizedNumber("user1", "group1").Should().BeInRange(0, 100);
+            StrategyUtils.GetNormalizedNumber("user1", "group1", 0).Should().BeInRange(0, 100);
 
             // Strange inputs
-            StrategyUtils.GetNormalizedNumber(null, null).Should().BeInRange(0, 100);
-            StrategyUtils.GetNormalizedNumber("", "").Should().BeInRange(0, 100);
-            StrategyUtils.GetNormalizedNumber("#%&/(", "§~:<>&nbsp;").Should().BeInRange(0, 100);
+            StrategyUtils.GetNormalizedNumber(null, null, 0).Should().BeInRange(0, 100);
+            StrategyUtils.GetNormalizedNumber("", "", 0).Should().BeInRange(0, 100);
+            StrategyUtils.GetNormalizedNumber("#%&/(", "§~:<>&nbsp;", 0).Should().BeInRange(0, 100);
         }
 
         [Test]
         public void GetNormalizedNumber_Is_Compatible_With_Java_And_Go_Implementations()
         {
-            Assert.AreEqual(73, StrategyUtils.GetNormalizedNumber("123", "gr1"));
-            Assert.AreEqual(25, StrategyUtils.GetNormalizedNumber("999", "groupX"));
+            Assert.AreEqual(73, StrategyUtils.GetNormalizedNumber("123", "gr1", 0));
+            Assert.AreEqual(25, StrategyUtils.GetNormalizedNumber("999", "groupX", 0));
         }
     }
 }

--- a/tests/Unleash.Tests/Variants/VariantUtilsTests.cs
+++ b/tests/Unleash.Tests/Variants/VariantUtilsTests.cs
@@ -83,7 +83,7 @@ namespace Unleash.Tests.Variants
 
             var context = new UnleashContext
             {
-                UserId = "163",
+                UserId = "15",
                 SessionId = "sessionId",
                 RemoteAddress = "remoteAddress",
                 Properties = new Dictionary<string, string>()
@@ -114,7 +114,7 @@ namespace Unleash.Tests.Variants
 
             var context = new UnleashContext
             {
-                UserId = "40",
+                UserId = "43",
                 SessionId = "sessionId",
                 RemoteAddress = "remoteAddress",
                 Properties = new Dictionary<string, string>()
@@ -261,7 +261,7 @@ namespace Unleash.Tests.Variants
         }
 
         [Test]
-        public void Custom_Stickiness_CustomField_528_Yields_Blue()
+        public void Custom_Stickiness_CustomField_419_Yields_Blue()
         {
             // Arrange
             var sessionId = "122221";
@@ -284,7 +284,7 @@ namespace Unleash.Tests.Variants
                 UserId = "11",
                 SessionId = sessionId,
                 RemoteAddress = "remoteAddress",
-                Properties = new Dictionary<string, string> { { "env", "prod" }, { "customField", "528" } }
+                Properties = new Dictionary<string, string> { { "env", "prod" }, { "customField", "419" } }
             };
 
             // Act
@@ -295,7 +295,7 @@ namespace Unleash.Tests.Variants
         }
 
         [Test]
-        public void Custom_Stickiness_CustomField_16_Yields_Blue()
+        public void Custom_Stickiness_CustomField_21_Yields_Blue()
         {
             // Arrange
             var sessionId = "122221";
@@ -318,7 +318,7 @@ namespace Unleash.Tests.Variants
                 UserId = "13",
                 SessionId = sessionId,
                 RemoteAddress = "remoteAddress",
-                Properties = new Dictionary<string, string> { { "env", "prod" }, { "customField", "16" } }
+                Properties = new Dictionary<string, string> { { "env", "prod" }, { "customField", "21" } }
             };
 
             // Act
@@ -329,7 +329,7 @@ namespace Unleash.Tests.Variants
         }
 
         [Test]
-        public void Custom_Stickiness_CustomField_198_Yields_Red()
+        public void Custom_Stickiness_CustomField_60_Yields_Red()
         {
             // Arrange
             var sessionId = "122221";
@@ -352,7 +352,7 @@ namespace Unleash.Tests.Variants
                 UserId = "13",
                 SessionId = sessionId,
                 RemoteAddress = "remoteAddress",
-                Properties = new Dictionary<string, string> { { "env", "prod" }, { "customField", "198" } }
+                Properties = new Dictionary<string, string> { { "env", "prod" }, { "customField", "60" } }
             };
 
             // Act
@@ -397,7 +397,7 @@ namespace Unleash.Tests.Variants
         }
 
         [Test]
-        public void Custom_Stickiness_CustomField_112_Yields_Yellow()
+        public void Custom_Stickiness_CustomField_13_Yields_Yellow()
         {
             // Arrange
             var sessionId = "122221";
@@ -420,7 +420,7 @@ namespace Unleash.Tests.Variants
                 UserId = "13",
                 SessionId = sessionId,
                 RemoteAddress = "remoteAddress",
-                Properties = new Dictionary<string, string> { { "env", "prod" }, { "customField", "112" } }
+                Properties = new Dictionary<string, string> { { "env", "prod" }, { "customField", "13" } }
             };
 
             // Act


### PR DESCRIPTION
**What**

Uses a new seed for ensuring a fair distrbution for variants.

**Background**

After a customer reported that variant distribution seemed skewed we performed some testing and found that since we use the same hash string for both gradual rollout and variant allocation we'd reduced the set of groups we could get to whatever percentage our gradual rollout was set.

**Example**

Take a gradualRollout of 10%, this will select normalized hashes between 1 and 10, when we then again hash the same string that gave us between 1 and 10, but with modulo 1000 for variants, this will only give us 100 possible groups, instead of the expected 1000.

**Fix**

Force the normalization to accept a seed, and make sure to use a new seed when normalizing the variant distribution hash.

**Worth noting**

This will require release 4.0.0, since we're changing the signature of public methods.