### PR TITLE
fix: make segment ids deserialize as ints instead of strings

### DIFF
--- a/src/Unleash/Internal/ActivationStrategy.cs
+++ b/src/Unleash/Internal/ActivationStrategy.cs
@@ -8,15 +8,15 @@ namespace Unleash.Internal
         public string Name { get; }
         public Dictionary<string, string> Parameters { get; }
         public List<Constraint> Constraints { get; }
-        public List<string> Segments { get; }
+        public List<int> Segments { get; }
         public List<VariantDefinition> Variants { get; }
 
-        public ActivationStrategy(string name, Dictionary<string, string> parameters, List<Constraint> constraints = null, List<string> segments = null, List<VariantDefinition> variants = null)
+        public ActivationStrategy(string name, Dictionary<string, string> parameters, List<Constraint> constraints = null, List<int> segments = null, List<VariantDefinition> variants = null)
         {
             Name = name;
             Parameters = parameters ?? new Dictionary<string, string>();
             Constraints = constraints ?? new List<Constraint>();
-            Segments = segments ?? new List<string>();
+            Segments = segments ?? new List<int>();
             Variants = variants ?? new List<VariantDefinition>();
         }
     }

--- a/src/Unleash/Internal/Segment.cs
+++ b/src/Unleash/Internal/Segment.cs
@@ -6,9 +6,9 @@ namespace Unleash.Internal
 {
     public class Segment
     {
-        public string Id { get; }
+        public int Id { get; }
         public List<Constraint> Constraints { get; }
-        public Segment(string id, List<Constraint> constraints = null)
+        public Segment(int id, List<Constraint> constraints = null)
         {
             Id = id;
             Constraints = constraints ?? new List<Constraint>();

--- a/src/Unleash/Internal/ToggleCollection.cs
+++ b/src/Unleash/Internal/ToggleCollection.cs
@@ -16,7 +16,7 @@ namespace Unleash.Internal
 
         private readonly Dictionary<string, FeatureToggle> togglesCache;
 
-        private readonly Dictionary<string, Segment> segmentsCache;
+        private readonly Dictionary<int, Segment> segmentsCache;
 
         public ToggleCollection(ICollection<FeatureToggle> features = null, ICollection<Segment> segments = null)
         {
@@ -24,7 +24,7 @@ namespace Unleash.Internal
             Segments = segments ?? new List<Segment>(0);
 
             togglesCache = new Dictionary<string, FeatureToggle>(Features.Count);
-            segmentsCache = new Dictionary<string, Segment>(Segments.Count);
+            segmentsCache = new Dictionary<int, Segment>(Segments.Count);
 
             foreach (var featureToggle in Features) {
                 togglesCache.Add(featureToggle.Name, featureToggle);
@@ -47,7 +47,7 @@ namespace Unleash.Internal
                 : null;
         }
 
-        public Segment GetSegmentById(string id)
+        public Segment GetSegmentById(int id)
         {
             return segmentsCache.TryGetValue(id, out var value)
                 ? value

--- a/tests/Unleash.Tests/Strategy/Segments_Tests.cs
+++ b/tests/Unleash.Tests/Strategy/Segments_Tests.cs
@@ -24,7 +24,7 @@ namespace Unleash.Tests.Strategy.Segments
         {
             // Arrange
             var appname = "masstest";
-            var segmentIds = new List<string>() { "1", "2" };
+            var segmentIds = new List<int>() { 1, 2 };
             var toggles = new List<FeatureToggle>()
             {
                 new FeatureToggle("item", "release", true, false, new List<ActivationStrategy>() { new ActivationStrategy("default", new Dictionary<string, string>(), null, segmentIds) })
@@ -49,7 +49,7 @@ namespace Unleash.Tests.Strategy.Segments
         {
             // Arrange
             var appname = "masstest";
-            var segmentIds = new List<string>() { "1" };
+            var segmentIds = new List<int>() { 1 };
             var toggles = new List<FeatureToggle>()
             {
                 new FeatureToggle("item", "release", true, false, new List<ActivationStrategy>() { new ActivationStrategy("default", new Dictionary<string, string>(), new List<Constraint>() { new Constraint("item-id", Operator.NUM_EQ, false, false, "15") }, segmentIds) })
@@ -74,7 +74,7 @@ namespace Unleash.Tests.Strategy.Segments
         {
             // Arrange
             var appname = "masstest";
-            var segmentIds = new List<string>() { "1" };
+            var segmentIds = new List<int>() { 1 };
             var toggles = new List<FeatureToggle>()
             {
                 new FeatureToggle("item", "release", true, false, new List<ActivationStrategy>() { new ActivationStrategy("default", new Dictionary<string, string>(), new List<Constraint>() { new Constraint("item-id", Operator.NUM_EQ, false, false, "1") }, segmentIds) })


### PR DESCRIPTION
# Description

Segment ids were being sent as numbers but deserialized into strings, which can cause deserialization errors. This fix changes the local type of segment ids to be ints

Fixes #173 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Running all unit tests

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules