### PR TITLE
Improve on Union performance

### DIFF
--- a/src/Unleash/DefaultUnleash.cs
+++ b/src/Unleash/DefaultUnleash.cs
@@ -156,11 +156,12 @@ namespace Unleash
             }
             else
             {
-                strategy = featureToggle.Strategies
-                    .FirstOrDefault(s =>
-                        GetStrategyOrUnknown(s.Name)
-                        .IsEnabled(s.Parameters, enhancedContext, ResolveConstraints(s).Union(s.Constraints))
-                    );
+                strategy = featureToggle.Strategies.FirstOrDefault(s =>
+                {
+                    var uniqueConstraints = new HashSet<Constraint>(ResolveConstraints(s));
+                    uniqueConstraints.UnionWith(s.Constraints);
+                    return GetStrategyOrUnknown(s.Name).IsEnabled(s.Parameters, enhancedContext, uniqueConstraints);
+                });
             }
 
             if (featureToggle.Dependencies.Any() && !ParentDependenciesAreSatisfied(featureToggle, enhancedContext))


### PR DESCRIPTION
# Description

In looking at our application which uses the dotnet Unleash client we found that a large amount of memory was being allocated by the client:
![image](https://github.com/Unleash/unleash-client-dotnet/assets/132582942/a5bc02a8-52f2-4060-9c1e-350a6c656797)

Looking at the callstack the `Union` call in `DefaultUnleash.DetermineIsEnabledAndStrategy` is what is allocating so many arrays. These allocations can be reduced by replacing the `Union` call with a preallocated `HashSet` (which is what `Union` uses).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
The following BenchmarkDotnet code was used to validate that this was better performing:

```
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Running;

var summary = BenchmarkRunner.Run<UnionExamples>();

Console.WriteLine(summary);

[MemoryDiagnoser]
public class UnionExamples
{
    const int Length = 1000;

    readonly IEnumerable<ExampleConstraint> first;
    readonly IEnumerable<ExampleConstraint> second;

    public UnionExamples()
    {
        first = Enumerable.Range(0, Length).Select(i => new ExampleConstraint { Id = i }).ToList();
        second = Enumerable.Range(0, Length).Reverse().Select(i => new ExampleConstraint { Id = i }).ToList();
    }

    [Benchmark(Baseline = true)]
    public int Union() => first.Union(second).Count();

    [Benchmark]
    public int Preallocate()
    {
        var unique = new HashSet<ExampleConstraint>(first);
        unique.UnionWith(second);
        return unique.Count;
    }

    [Benchmark]
    public int ConcatDistinct() => first.Concat(second).Distinct().Count();
}

class ExampleConstraint { public int Id { get; set; } }
```
With the results being:
| Method         | Mean     | Error    | StdDev   | Ratio | RatioSD | Gen0    | Gen1   | Allocated | Alloc Ratio |
|--------------- |---------:|---------:|---------:|------:|--------:|--------:|-------:|----------:|------------:|
| Union          | 53.58 us | 1.055 us | 1.215 us |  1.00 |    0.00 | 12.2681 | 4.0283 | 150.72 KB |        1.00 |
| Preallocate    | 45.31 us | 0.666 us | 0.713 us |  0.84 |    0.02 |  5.4932 | 1.3428 |  67.35 KB |        0.45 |
| ConcatDistinct | 64.52 us | 0.762 us | 0.712 us |  1.20 |    0.03 | 12.2070 | 4.0283 | 150.77 KB |        1.00 |

So my proposed change uses less CPU and memory then the current `Union`.