### PR TITLE
feat: implement skipping backoff strategy

### DIFF
--- a/src/Unleash/Communication/UnleashApiClient.cs
+++ b/src/Unleash/Communication/UnleashApiClient.cs
@@ -1,5 +1,8 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
+using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Threading;
@@ -21,7 +24,26 @@ namespace Unleash.Communication
         private readonly UnleashApiClientRequestHeaders clientRequestHeaders;
         private readonly EventCallbackConfig eventConfig;
         private readonly string projectId;
-
+        private int featureClientToSkip = 0;
+        private int featureClientSkipped = 0;
+        private int metricsClientToSkip = 0;
+        private int metricsClientSkipped = 0;
+        private readonly int[] backoffResponses = 
+            new int[]
+                {
+                    429,
+                    500,
+                    502,
+                    503,
+                    504                 
+                };
+        private readonly int[] configurationErrorResponses =
+            new int[]
+                {
+                    401,
+                    403,
+                    404,
+                };
         public UnleashApiClient(
             HttpClient httpClient, 
             IJsonSerializer jsonSerializer, 
@@ -38,6 +60,18 @@ namespace Unleash.Communication
 
         public async Task<FetchTogglesResult> FetchToggles(string etag, CancellationToken cancellationToken)
         {
+            if (featureClientToSkip > featureClientSkipped)
+            {
+                featureClientSkipped++;
+                return new FetchTogglesResult
+                {
+                    HasChanged = false,
+                    Etag = null,
+                };
+            }
+
+            featureClientSkipped = 0;
+
             string resourceUri = "client/features";
             if (!string.IsNullOrWhiteSpace(this.projectId))
                 resourceUri += "?project=" + this.projectId;
@@ -51,10 +85,9 @@ namespace Unleash.Communication
 
                 using (var response = await httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false))
                 {
-                    if (!response.IsSuccessStatusCode && response.StatusCode != System.Net.HttpStatusCode.NotModified)
+                    if (!response.IsSuccessStatusCode && response.StatusCode != HttpStatusCode.NotModified)
                     {
-                        {
-                        return await HandleErrorResponse(response);
+                        return await HandleErrorResponse(response, resourceUri);
                     }
 
                     return await HandleSuccessResponse(response, etag);
@@ -62,8 +95,18 @@ namespace Unleash.Communication
             }
         }
 
-        private async Task<FetchTogglesResult> HandleErrorResponse(HttpResponseMessage response)
+        private async Task<FetchTogglesResult> HandleErrorResponse(HttpResponseMessage response, string resourceUri)
         {
+            if (backoffResponses.Contains((int)response.StatusCode))
+            {
+                Backoff(response);
+            }
+
+            if (configurationErrorResponses.Contains((int)response.StatusCode))
+            {
+                ConfigurationError(response, resourceUri);
+            }
+
             var error = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
             Logger.Trace($"UNLEASH: Error {response.StatusCode} from server in '{nameof(FetchToggles)}': " + error);
             eventConfig?.RaiseError(new ErrorEvent() { ErrorType = ErrorType.Client, StatusCode = response.StatusCode, Resource = resourceUri });
@@ -74,9 +117,34 @@ namespace Unleash.Communication
                 Etag = null,
             };
         }
+        private void Backoff(HttpResponseMessage response)
+        {
+            featureClientToSkip = Math.Min(10, featureClientToSkip + 1);
+            Logger.Warn($"UNLEASH: Backing off due to {response.StatusCode} from server in '{nameof(FetchToggles)}'.");
+        }
+
+        private void ConfigurationError(HttpResponseMessage response, string requestUri)
+        {
+            featureClientToSkip = 10;
+
+            if (response.StatusCode == HttpStatusCode.NotFound)
+            {
+                Logger.Error($"UNLEASH: Error when fetching toggles, {requestUri} responded NOT_FOUND (404) which means your API url most likely needs correction.'.");
+            }
+            else if (response.StatusCode == HttpStatusCode.Unauthorized || response.StatusCode == HttpStatusCode.Forbidden)
+            {
+                Logger.Error($"UNLEASH: Error when fetching toggles, {requestUri} responded FORBIDDEN (403) which means your API token is not valid.");
+            }
+            else
+            {
+                Logger.Error($"UNLEASH: Configuration error due to {response.StatusCode} from server in '{nameof(FetchToggles)}'.");
+            }
+        }
 
         private async Task<FetchTogglesResult> HandleSuccessResponse(HttpResponseMessage response, string etag)
         {
+            featureClientToSkip = Math.Max(0, featureClientToSkip - 1);
+
             var newEtag = response.Headers.ETag?.Tag;
             if (newEtag == etag)
             { 
@@ -115,11 +183,39 @@ namespace Unleash.Communication
             var memoryStream = new MemoryStream();
             jsonSerializer.Serialize(memoryStream, registration);
 
-            return await Post(requestUri, memoryStream, cancellationToken).ConfigureAwait(false);
+            const int bufferSize = 1024 * 4;
+
+            using (var request = new HttpRequestMessage(HttpMethod.Post, requestUri))
+            {
+                request.Content = new StreamContent(memoryStream, bufferSize);
+                request.Content.Headers.AddContentTypeJson();
+
+                SetRequestHeaders(request, clientRequestHeaders);
+
+                using (var response = await httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false))
+                {
+                    if (response.IsSuccessStatusCode)
+                        return true;
+
+                    var error = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    Logger.Trace($"UNLEASH: Error {response.StatusCode} from request '{requestUri}' in '{nameof(UnleashApiClient)}': " + error);
+                    eventConfig?.RaiseError(new ErrorEvent() { Resource = requestUri, ErrorType = ErrorType.Client, StatusCode = response.StatusCode });
+
+                    return false;
+                }
+            }
         }
 
         public async Task<bool> SendMetrics(ThreadSafeMetricsBucket metrics, CancellationToken cancellationToken)
         {
+            if (metricsClientToSkip > metricsClientSkipped)
+            {
+                metricsClientSkipped++;
+                return false;
+            }
+
+            metricsClientSkipped = 0;
+
             const string requestUri = "client/metrics";
 
             var memoryStream = new MemoryStream();
@@ -134,32 +230,49 @@ namespace Unleash.Communication
                 });
             }
 
-            return await Post(requestUri, memoryStream, cancellationToken).ConfigureAwait(false);
-        }
-
-        private async Task<bool> Post(string resourceUri, Stream stream, CancellationToken cancellationToken)
-        {
             const int bufferSize = 1024 * 4;
 
-            using (var request = new HttpRequestMessage(HttpMethod.Post, resourceUri))
+            using (var request = new HttpRequestMessage(HttpMethod.Post, requestUri))
             {
-                request.Content = new StreamContent(stream, bufferSize);
+                request.Content = new StreamContent(memoryStream, bufferSize);
                 request.Content.Headers.AddContentTypeJson();
 
                 SetRequestHeaders(request, clientRequestHeaders);
 
                 using (var response = await httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false))
                 {
-                    if (response.IsSuccessStatusCode)
+                    if (response.IsSuccessStatusCode || response.StatusCode == HttpStatusCode.NotModified)
+                    {
+                        HandleMetricsSuccessResponse(response);
                         return true;
+                    }
 
-                    var error = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    Logger.Trace($"UNLEASH: Error {response.StatusCode} from request '{resourceUri}' in '{nameof(UnleashApiClient)}': " + error);
-                    eventConfig?.RaiseError(new ErrorEvent() { Resource = resourceUri, ErrorType = ErrorType.Client, StatusCode = response.StatusCode });
-
+                    await HandleMetricsErrorResponse(response, requestUri);
                     return false;
                 }
             }
+        }
+
+        private async Task HandleMetricsErrorResponse(HttpResponseMessage response, string requestUri)
+        {
+            if (backoffResponses.Contains((int)response.StatusCode))
+            {
+                metricsClientToSkip = Math.Min(10, metricsClientToSkip + 1);
+            }
+
+            if (configurationErrorResponses.Contains((int)response.StatusCode))
+            {
+                metricsClientToSkip = 10;
+            }
+
+            var error = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+            Logger.Trace($"UNLEASH: Error {response.StatusCode} from request '{requestUri}' in '{nameof(UnleashApiClient)}': " + error);
+            eventConfig?.RaiseError(new ErrorEvent() { Resource = requestUri, ErrorType = ErrorType.Client, StatusCode = response.StatusCode });
+        }
+
+        private void HandleMetricsSuccessResponse(HttpResponseMessage response)
+        {
+            metricsClientToSkip = Math.Max(0, metricsClientToSkip - 1);
         }
 
         private static void SetRequestHeaders(HttpRequestMessage requestMessage, UnleashApiClientRequestHeaders headers)

--- a/src/Unleash/Communication/UnleashApiClient.cs
+++ b/src/Unleash/Communication/UnleashApiClient.cs
@@ -64,37 +64,42 @@ namespace Unleash.Communication
                         };
                     }
 
-                    var newEtag = response.Headers.ETag?.Tag;
-                    if (newEtag == etag)
-                    { 
-                        return new FetchTogglesResult
-                        {
-                            HasChanged = false,
-                            Etag = newEtag,
-                            ToggleCollection = null,
-                        };
-                    }
-
-                    var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
-                    var toggleCollection = jsonSerializer.Deserialize<ToggleCollection>(stream);
-
-                    if (toggleCollection == null)
-                    {
-                        return new FetchTogglesResult
-                        {
-                            HasChanged = false
-                        };
-                    }
-
-                    // Success
-                    return new FetchTogglesResult
-                    {
-                        HasChanged = true,
-                        Etag = newEtag,
-                        ToggleCollection = toggleCollection
-                    };
+                    return await HandleSuccessResponse(response, etag);
                 }
             }
+        }
+
+        private async Task<FetchTogglesResult> HandleSuccessResponse(HttpResponseMessage response, string etag)
+        {
+            var newEtag = response.Headers.ETag?.Tag;
+            if (newEtag == etag)
+            { 
+                return new FetchTogglesResult
+                {
+                    HasChanged = false,
+                    Etag = newEtag,
+                    ToggleCollection = null,
+                };
+            }
+
+            var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+            var toggleCollection = jsonSerializer.Deserialize<ToggleCollection>(stream);
+
+            if (toggleCollection == null)
+            {
+                return new FetchTogglesResult
+                {
+                    HasChanged = false
+                };
+            }
+
+            // Success
+            return new FetchTogglesResult
+            {
+                HasChanged = true,
+                Etag = newEtag,
+                ToggleCollection = toggleCollection
+            };
         }
 
         public async Task<bool> RegisterClient(ClientRegistration registration, CancellationToken cancellationToken)

--- a/tests/Unleash.Tests/Communication/BaseBackoffTest.cs
+++ b/tests/Unleash.Tests/Communication/BaseBackoffTest.cs
@@ -1,0 +1,95 @@
+using System.Net;
+using FakeItEasy;
+using Unleash.Communication;
+using Unleash.Internal;
+using Unleash.Serialization;
+
+public class BaseBackoffTest
+{
+    internal class CountingConfigurableHttpMessageHandler : HttpMessageHandler
+    {
+        private readonly List<HttpResponseMessage> responses;
+        public int CallCount { get; set; }
+
+        public CountingConfigurableHttpMessageHandler(List<HttpResponseMessage> responses)
+        {
+            this.responses = responses;
+        }
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var response = responses[CallCount];
+            CallCount++;
+            return response;
+        }
+    }
+
+    internal UnleashApiClient GetClient(HttpMessageHandler messageHandler)
+    {
+        var httpClient = new HttpClient(messageHandler);
+        httpClient.BaseAddress = new Uri("http://localhost:8080/");
+
+        var apiClient = new UnleashApiClient(
+            httpClient,
+            A.Fake<IJsonSerializer>(),
+            A.Fake<UnleashApiClientRequestHeaders>(),
+            new EventCallbackConfig()
+        );
+        return apiClient;
+    }
+
+    protected static HttpResponseMessage Ok => 
+        new HttpResponseMessage
+        {
+            StatusCode = HttpStatusCode.OK,
+            Content = new StringContent("")
+        };
+
+    protected static HttpResponseMessage NotModified => 
+        new HttpResponseMessage
+        {
+            StatusCode = HttpStatusCode.NotModified,
+            Content = new StringContent("{}")
+        };
+
+    protected static HttpResponseMessage TooManyRequests => 
+        new HttpResponseMessage
+        {
+            StatusCode = HttpStatusCode.TooManyRequests,
+            Content = new StringContent("")
+        };
+    
+    protected static HttpResponseMessage InternalServerError =>
+        new HttpResponseMessage
+        {
+            StatusCode = HttpStatusCode.InternalServerError,
+            Content = new StringContent("")
+        };
+
+    protected static HttpResponseMessage BadGateway =>
+        new HttpResponseMessage
+        {
+            StatusCode = HttpStatusCode.BadGateway,
+            Content = new StringContent("")
+        };
+
+    protected static HttpResponseMessage ServiceUnavailable =>
+        new HttpResponseMessage
+        {
+            StatusCode = HttpStatusCode.ServiceUnavailable,
+            Content = new StringContent("")
+        };
+
+    protected static HttpResponseMessage Forbidden =>
+        new HttpResponseMessage
+        {
+            StatusCode = HttpStatusCode.Forbidden,
+            Content = new StringContent("")
+        };
+
+    protected static HttpResponseMessage Unauthorized =>
+        new HttpResponseMessage
+        {
+            StatusCode = HttpStatusCode.Unauthorized,
+            Content = new StringContent("")
+        };
+}

--- a/tests/Unleash.Tests/Communication/BaseBackoffTest.cs
+++ b/tests/Unleash.Tests/Communication/BaseBackoffTest.cs
@@ -37,6 +37,9 @@ public class BaseBackoffTest
         return apiClient;
     }
 
+    /// <summary>
+    /// 200 OK
+    /// </summary>
     protected static HttpResponseMessage Ok => 
         new HttpResponseMessage
         {
@@ -44,41 +47,29 @@ public class BaseBackoffTest
             Content = new StringContent("")
         };
 
+    /// <summary>
+    /// 304 Not Modified
+    /// </summary>
     protected static HttpResponseMessage NotModified => 
         new HttpResponseMessage
         {
             StatusCode = HttpStatusCode.NotModified,
             Content = new StringContent("{}")
         };
-
-    protected static HttpResponseMessage TooManyRequests => 
-        new HttpResponseMessage
-        {
-            StatusCode = HttpStatusCode.TooManyRequests,
-            Content = new StringContent("")
-        };
     
-    protected static HttpResponseMessage InternalServerError =>
+    /// <summary>
+    /// 401 Unauthorized
+    /// </summary>
+    protected static HttpResponseMessage Unauthorized =>
         new HttpResponseMessage
         {
-            StatusCode = HttpStatusCode.InternalServerError,
+            StatusCode = HttpStatusCode.Unauthorized,
             Content = new StringContent("")
         };
 
-    protected static HttpResponseMessage BadGateway =>
-        new HttpResponseMessage
-        {
-            StatusCode = HttpStatusCode.BadGateway,
-            Content = new StringContent("")
-        };
-
-    protected static HttpResponseMessage ServiceUnavailable =>
-        new HttpResponseMessage
-        {
-            StatusCode = HttpStatusCode.ServiceUnavailable,
-            Content = new StringContent("")
-        };
-
+    /// <summary>
+    /// 403 Forbidden
+    /// </summary>
     protected static HttpResponseMessage Forbidden =>
         new HttpResponseMessage
         {
@@ -86,10 +77,63 @@ public class BaseBackoffTest
             Content = new StringContent("")
         };
 
-    protected static HttpResponseMessage Unauthorized =>
+    /// <summary>
+    /// 404 Not Found
+    /// </summary>
+    protected static HttpResponseMessage NotFound =>
         new HttpResponseMessage
         {
-            StatusCode = HttpStatusCode.Unauthorized,
+            StatusCode = HttpStatusCode.NotFound,
+            Content = new StringContent("")
+        };
+
+    /// <summary>
+    /// 429 Too Many Requests
+    /// </summary>
+    protected static HttpResponseMessage TooManyRequests => 
+        new HttpResponseMessage
+        {
+            StatusCode = HttpStatusCode.TooManyRequests,
+            Content = new StringContent("")
+        };
+    
+    /// <summary>
+    /// 500 Internal Server Error
+    /// </summary>
+    protected static HttpResponseMessage InternalServerError =>
+        new HttpResponseMessage
+        {
+            StatusCode = HttpStatusCode.InternalServerError,
+            Content = new StringContent("")
+        };
+
+    /// <summary>
+    /// 502 Bad Gateway
+    /// </summary>
+    protected static HttpResponseMessage BadGateway =>
+        new HttpResponseMessage
+        {
+            StatusCode = HttpStatusCode.BadGateway,
+            Content = new StringContent("")
+        };
+
+    /// <summary>
+    /// 503 Service Unavailable
+    /// </summary>
+    protected static HttpResponseMessage ServiceUnavailable =>
+        new HttpResponseMessage
+        {
+            StatusCode = HttpStatusCode.ServiceUnavailable,
+            Content = new StringContent("")
+        };
+
+    /// <summary>
+    /// 504 Gateway Timeout
+    /// </summary>
+    protected static HttpResponseMessage GatewayTimeout =>
+        new HttpResponseMessage
+        {
+            StatusCode = HttpStatusCode.GatewayTimeout,
             Content = new StringContent("")
         };
 }

--- a/tests/Unleash.Tests/Communication/UnleashApiClient_Features_Backoff_Tests.cs
+++ b/tests/Unleash.Tests/Communication/UnleashApiClient_Features_Backoff_Tests.cs
@@ -187,11 +187,11 @@ public class UnleashApiClient_Features_Backoff_Tests : BaseBackoffTest
             new List<HttpResponseMessage>
             {
                 TooManyRequests,
+                InternalServerError,
+                GatewayTimeout,
                 TooManyRequests,
-                TooManyRequests,
-                TooManyRequests,
-                TooManyRequests,
-                TooManyRequests,
+                ServiceUnavailable,
+                BadGateway,
                 TooManyRequests,
                 TooManyRequests,
                 TooManyRequests,

--- a/tests/Unleash.Tests/Communication/UnleashApiClient_Features_Backoff_Tests.cs
+++ b/tests/Unleash.Tests/Communication/UnleashApiClient_Features_Backoff_Tests.cs
@@ -1,0 +1,263 @@
+using System.Net;
+using FakeItEasy;
+using FluentAssertions;
+using NUnit.Framework;
+using Unleash.Communication;
+using Unleash.Internal;
+using Unleash.Serialization;
+
+public class UnleashApiClient_Features_Backoff_Tests : BaseBackoffTest
+{
+    [Test]
+    public void Should_Not_Skip_First_Call()
+    {
+        // Arrange
+        var messageHandler = new CountingConfigurableHttpMessageHandler
+        (
+            new List<HttpResponseMessage>
+            {
+                Ok
+            }
+        );
+        var httpClient = new HttpClient(messageHandler);
+        httpClient.BaseAddress = new Uri("http://localhost:8080/");
+
+        var apiClient = new UnleashApiClient(
+            httpClient,
+            A.Fake<IJsonSerializer>(),
+            A.Fake<UnleashApiClientRequestHeaders>(),
+            new EventCallbackConfig()
+        );
+
+        // Act
+        var result = Task.Run(() => apiClient.FetchToggles("etag", CancellationToken.None))
+            .GetAwaiter()
+            .GetResult();
+        
+        // Assert
+        messageHandler.CallCount.Should().Be(1);
+    }
+
+    [Test]
+    public void NotModified_Should_Not_Skip_Next()
+    {
+        // Arrange
+        var messageHandler = new CountingConfigurableHttpMessageHandler
+        (
+            new List<HttpResponseMessage>
+            {
+                NotModified,
+                Ok
+            }
+        );
+        var httpClient = new HttpClient(messageHandler);
+        httpClient.BaseAddress = new Uri("http://localhost:8080/");
+
+        var apiClient = new UnleashApiClient(
+            httpClient,
+            A.Fake<IJsonSerializer>(),
+            A.Fake<UnleashApiClientRequestHeaders>(),
+            new EventCallbackConfig()
+        );
+
+        // Act
+        var result = Task.Run(() => apiClient.FetchToggles("etag", CancellationToken.None))
+            .GetAwaiter()
+            .GetResult();
+        var result2 = Task.Run(() => apiClient.FetchToggles("etag", CancellationToken.None))
+            .GetAwaiter()
+            .GetResult();
+        
+        // Assert
+        messageHandler.CallCount.Should().Be(2);
+    }
+
+    [Test]
+    public void Should_Skip_One_After_First_429()
+    {
+        // Arrange
+        var messageHandler = new CountingConfigurableHttpMessageHandler
+        (
+            new List<HttpResponseMessage>
+            {
+                TooManyRequests,
+                Ok
+            }
+        );
+        var apiClient = GetClient(messageHandler);
+
+        // Act 1
+        var result = Task.Run(() => apiClient.FetchToggles("etag", CancellationToken.None))
+            .GetAwaiter()
+            .GetResult();
+
+        // Assert 1
+        messageHandler.CallCount.Should().Be(1);
+
+        // Act 2
+        var result2 = Task.Run(() => apiClient.FetchToggles("etag", CancellationToken.None))
+            .GetAwaiter()
+            .GetResult();
+
+        // Assert 2
+        messageHandler.CallCount.Should().Be(1);
+
+        // Act 3
+        var result3 = Task.Run(() => apiClient.FetchToggles("etag", CancellationToken.None))
+            .GetAwaiter()
+            .GetResult();
+
+        // Assert 3
+        messageHandler.CallCount.Should().Be(2);
+    }
+
+    [Test]
+    public void Backoff_Caps_Out_At_10() {
+        // Arrange
+        var messageHandler = new CountingConfigurableHttpMessageHandler
+        (
+            new List<HttpResponseMessage>
+            {
+                TooManyRequests,
+                TooManyRequests,
+                TooManyRequests,
+                TooManyRequests,
+                TooManyRequests,
+                TooManyRequests,
+                TooManyRequests,
+                TooManyRequests,
+                TooManyRequests,
+                TooManyRequests,
+                Ok,
+                Ok
+            }
+        );
+
+        var client = GetClient(messageHandler);
+
+        // Act
+        for (var i = 0; i < 55; i++)
+        {
+            var loopResult = Task.Run(() => client.FetchToggles("etag", CancellationToken.None))
+                .GetAwaiter()
+                .GetResult();
+        }
+
+        for (var i = 0; i < 10; i++)
+        {
+            var loopResult = Task.Run(() => client.FetchToggles("etag", CancellationToken.None))
+                .GetAwaiter()
+                .GetResult();
+        }
+
+        messageHandler.CallCount.Should().Be(10);
+
+        var resultAfter = Task.Run(() => client.FetchToggles("etag", CancellationToken.None))
+            .GetAwaiter()
+            .GetResult();
+
+        // Assert
+        // Calls on the 11th retry
+        messageHandler.CallCount.Should().Be(11);
+
+        // Another loop of 9
+        for (var i = 0; i < 9; i++)
+        {
+            var loopResult = Task.Run(() => client.FetchToggles("etag", CancellationToken.None))
+                .GetAwaiter()
+                .GetResult();
+        }
+
+        // Shouldn't have changed
+        messageHandler.CallCount.Should().Be(11);
+
+        var resultAfter2 = Task.Run(() => client.FetchToggles("etag", CancellationToken.None))
+            .GetAwaiter()
+            .GetResult();
+
+        // Should have made 1 additional attempt as part of decrease
+        messageHandler.CallCount.Should().Be(12);
+   }
+
+    [Test]
+    public void Backoff_Gradually_Decreases() {
+        // Arrange
+        var messageHandler = new CountingConfigurableHttpMessageHandler
+        (
+            new List<HttpResponseMessage>
+            {
+                TooManyRequests,
+                TooManyRequests,
+                TooManyRequests,
+                TooManyRequests,
+                TooManyRequests,
+                TooManyRequests,
+                TooManyRequests,
+                TooManyRequests,
+                TooManyRequests,
+                TooManyRequests,
+                Ok,
+                Ok,
+                Ok,
+                Ok
+            }
+        );
+
+        var client = GetClient(messageHandler);
+
+        // Act
+        for (var i = 0; i < 55; i++)
+        {
+            var loopResult = Task.Run(() => client.FetchToggles("etag", CancellationToken.None))
+                .GetAwaiter()
+                .GetResult();
+        }
+
+        for (var i = 0; i < 11; i++)
+        {
+          var loopResult = Task.Run(() => client.FetchToggles("etag", CancellationToken.None))
+              .GetAwaiter()
+              .GetResult();
+        }
+
+        // Still takes 11 fetches to get a new GET, this one will return 200 so the backoff should decrease
+        messageHandler.CallCount.Should().Be(11);
+
+        // Make 9 more fetches
+        for (var i = 0; i < 9; i++)
+        {
+            var loopResult = Task.Run(() => client.FetchToggles("etag", CancellationToken.None))
+                .GetAwaiter()
+                .GetResult();
+        }
+
+        // Backoff should be at 9, so this should not have increased CallCount
+        messageHandler.CallCount.Should().Be(11);
+
+        // Make the 10th fetch, this one should cause a GET
+        var resultAfter2 = Task.Run(() => client.FetchToggles("etag", CancellationToken.None))
+            .GetAwaiter()
+            .GetResult();
+
+        // Should have made 1 additional attempt
+        messageHandler.CallCount.Should().Be(12);
+
+        // Make 8 more fetches
+        for (var i = 0; i < 8; i++)
+        {
+            var loopResult = Task.Run(() => client.FetchToggles("etag", CancellationToken.None))
+                .GetAwaiter()
+                .GetResult();
+        }
+
+        // Backoff should be at 8, so this should not have increased CallCount
+        messageHandler.CallCount.Should().Be(12);
+
+        // Make the 9th fetch, this one should cause a GET
+        var resultAfter3 = Task.Run(() => client.FetchToggles("etag", CancellationToken.None))
+            .GetAwaiter()
+            .GetResult();
+
+        messageHandler.CallCount.Should().Be(13);
+    }
+}

--- a/tests/Unleash.Tests/Communication/UnleashApiClient_Features_Backoff_Tests.cs
+++ b/tests/Unleash.Tests/Communication/UnleashApiClient_Features_Backoff_Tests.cs
@@ -160,7 +160,6 @@ public class UnleashApiClient_Features_Backoff_Tests : BaseBackoffTest
         // Calls on the 11th retry
         messageHandler.CallCount.Should().Be(11);
 
-        // Another loop of 9
         for (var i = 0; i < 9; i++)
         {
             var loopResult = Task.Run(() => client.FetchToggles("etag", CancellationToken.None))

--- a/tests/Unleash.Tests/Communication/UnleashApiClient_Metrics_Backoff_Tests.cs
+++ b/tests/Unleash.Tests/Communication/UnleashApiClient_Metrics_Backoff_Tests.cs
@@ -86,10 +86,10 @@ public class UnleashApiClient_Metrics_Backoff_Tests : BaseBackoffTest
                 TooManyRequests,
                 InternalServerError,
                 InternalServerError,
-                TooManyRequests,
-                TooManyRequests,
-                TooManyRequests,
-                TooManyRequests,
+                GatewayTimeout,
+                BadGateway,
+                ServiceUnavailable,
+                Forbidden,
                 Unauthorized,
                 Ok
             }

--- a/tests/Unleash.Tests/Communication/UnleashApiClient_Metrics_Backoff_Tests.cs
+++ b/tests/Unleash.Tests/Communication/UnleashApiClient_Metrics_Backoff_Tests.cs
@@ -1,0 +1,251 @@
+using FakeItEasy;
+using FluentAssertions;
+using NUnit.Framework;
+using Unleash.Communication;
+using Unleash.Internal;
+using Unleash.Serialization;
+
+public class UnleashApiClient_Metrics_Backoff_Tests : BaseBackoffTest
+{
+    [Test]
+    public void Should_not_skip_first_call()
+    {
+        // Arrange
+        var messageHandler = new CountingConfigurableHttpMessageHandler
+        (
+            new List<HttpResponseMessage>
+            {
+                Ok
+            }
+        );
+        var httpClient = new HttpClient(messageHandler);
+        httpClient.BaseAddress = new Uri("http://localhost:8080/");
+
+        var apiClient = new UnleashApiClient(
+            httpClient,
+            A.Fake<IJsonSerializer>(),
+            A.Fake<UnleashApiClientRequestHeaders>(),
+            new EventCallbackConfig()
+        );
+
+        // Act
+        var result = Task.Run(() => apiClient.FetchToggles("etag", CancellationToken.None))
+            .GetAwaiter()
+            .GetResult();
+        
+        // Assert
+        messageHandler.CallCount.Should().Be(1);
+    }
+
+    [Test]
+    public void NotModified_Should_Not_Skip_Next()
+    {
+        // Arrange
+        var messageHandler = new CountingConfigurableHttpMessageHandler
+        (
+            new List<HttpResponseMessage>
+            {
+                NotModified,
+                Ok
+            }
+        );
+        var httpClient = new HttpClient(messageHandler);
+        httpClient.BaseAddress = new Uri("http://localhost:8080/");
+
+        var apiClient = new UnleashApiClient(
+            httpClient,
+            A.Fake<IJsonSerializer>(),
+            A.Fake<UnleashApiClientRequestHeaders>(),
+            new EventCallbackConfig()
+        );
+
+        // Act
+        var result = Task.Run(() => apiClient.FetchToggles("etag", CancellationToken.None))
+            .GetAwaiter()
+            .GetResult();
+        var result2 = Task.Run(() => apiClient.FetchToggles("etag", CancellationToken.None))
+            .GetAwaiter()
+            .GetResult();
+        
+        // Assert
+        messageHandler.CallCount.Should().Be(2);
+    }
+
+    [Test]
+    public void Backoff_Caps_Out_At_10()
+    {
+        // Arrange
+        var messageHandler = new CountingConfigurableHttpMessageHandler
+        (
+            new List<HttpResponseMessage>
+            {
+                TooManyRequests,
+                TooManyRequests,
+                InternalServerError,
+                TooManyRequests,
+                TooManyRequests,
+                InternalServerError,
+                InternalServerError,
+                TooManyRequests,
+                TooManyRequests,
+                TooManyRequests,
+                TooManyRequests,
+                Unauthorized,
+                Ok
+            }
+        );
+        var httpClient = new HttpClient(messageHandler);
+        httpClient.BaseAddress = new Uri("http://localhost:8080/");
+
+        var apiClient = new UnleashApiClient(
+            httpClient,
+            A.Fake<IJsonSerializer>(),
+            A.Fake<UnleashApiClientRequestHeaders>(),
+            new EventCallbackConfig()
+        );
+
+        // Act
+        var result = Task.Run(() => apiClient.FetchToggles("etag", CancellationToken.None))
+            .GetAwaiter()
+            .GetResult();
+        
+        // Assert
+        messageHandler.CallCount.Should().Be(1);
+    }
+
+    [Test]
+    public void Should_Skip_One_After_First_429()
+    {
+        // Arrange
+        var messageHandler = new CountingConfigurableHttpMessageHandler
+        (
+            new List<HttpResponseMessage>
+            {
+                TooManyRequests,
+                Ok
+            }
+        );
+        var apiClient = GetClient(messageHandler);
+
+        // Act 1
+        var result = Task.Run(() => apiClient.FetchToggles("etag", CancellationToken.None))
+            .GetAwaiter()
+            .GetResult();
+
+        // Assert 1
+        messageHandler.CallCount.Should().Be(1);
+
+        // Act 2
+        var result2 = Task.Run(() => apiClient.FetchToggles("etag", CancellationToken.None))
+            .GetAwaiter()
+            .GetResult();
+        var result3 = Task.Run(() => apiClient.FetchToggles("etag", CancellationToken.None))
+            .GetAwaiter()
+            .GetResult();
+
+        // Assert 2
+        messageHandler.CallCount.Should().Be(2);
+    }
+
+    [Test]
+    public void Access_Error_Responses_Goes_Straight_To_Ten()
+    {
+        // Arrange
+        var messageHandler = new CountingConfigurableHttpMessageHandler
+        (
+            new List<HttpResponseMessage>
+            {
+                Unauthorized,
+                Ok
+            }
+        );
+        var apiClient = GetClient(messageHandler);
+
+        // Act 1
+        var result = Task.Run(() => apiClient.FetchToggles("etag", CancellationToken.None))
+            .GetAwaiter()
+            .GetResult();
+
+        // Assert 1
+        messageHandler.CallCount.Should().Be(1);
+
+        // Act 2
+        for (var i = 0; i < 10; i++)
+        {
+            var innerResult = Task.Run(() => apiClient.FetchToggles("etag", CancellationToken.None))
+                .GetAwaiter()
+                .GetResult();
+        }
+
+        messageHandler.CallCount.Should().Be(1);
+
+        // This the 11th call should be allowed through and cause an increase in CallCount
+        var result2 = Task.Run(() => apiClient.FetchToggles("etag", CancellationToken.None))
+            .GetAwaiter()
+            .GetResult();
+
+        // Assert 2
+        messageHandler.CallCount.Should().Be(2);
+    }
+
+    [Test]
+    public void Backoff_Gradually_Decreases()
+    {
+        // Arrange
+        var messageHandler = new CountingConfigurableHttpMessageHandler
+        (
+            new List<HttpResponseMessage>
+            {
+                Unauthorized,
+                Ok,
+                Ok,
+                Ok,
+                Ok
+            }
+        );
+        var apiClient = GetClient(messageHandler);
+
+        // Unauthorized = 10 skips
+        var result = Task.Run(() => apiClient.FetchToggles("etag", CancellationToken.None))
+            .GetAwaiter()
+            .GetResult();
+
+
+        // 11 attempts = 1 additional call attempt - which returns 200
+        for (var i = 0; i < 11; i++)
+        {
+            var innerResult = Task.Run(() => apiClient.FetchToggles("etag", CancellationToken.None))
+                .GetAwaiter()
+                .GetResult();
+        }
+
+        messageHandler.CallCount.Should().Be(2);
+
+        // 10 attempts = 1 additional call attempt (should have decreased to 9 skips) - returns 200
+        for (var i = 0; i < 10; i++)
+        {
+            var innerResult = Task.Run(() => apiClient.FetchToggles("etag", CancellationToken.None))
+                .GetAwaiter()
+                .GetResult();
+        }
+
+        messageHandler.CallCount.Should().Be(3);
+
+        // Should have decreased to 8 skips, so making 8 tries here so we can verify
+        for (var i = 0; i < 8; i++)
+        {
+            var innerResult = Task.Run(() => apiClient.FetchToggles("etag", CancellationToken.None))
+                .GetAwaiter()
+                .GetResult();
+        }
+
+        messageHandler.CallCount.Should().Be(3);
+
+        // Make one more attempt - should result in an attempt
+        var result2 = Task.Run(() => apiClient.FetchToggles("etag", CancellationToken.None))
+            .GetAwaiter()
+            .GetResult();
+
+        messageHandler.CallCount.Should().Be(4);
+    }
+}

--- a/tests/Unleash.Tests/Communication/UnleashApiClient_Metrics_Backoff_Tests.cs
+++ b/tests/Unleash.Tests/Communication/UnleashApiClient_Metrics_Backoff_Tests.cs
@@ -8,7 +8,7 @@ using Unleash.Serialization;
 public class UnleashApiClient_Metrics_Backoff_Tests : BaseBackoffTest
 {
     [Test]
-    public void Should_not_skip_first_call()
+    public void Should_Not_Skip_First_Call()
     {
         // Arrange
         var messageHandler = new CountingConfigurableHttpMessageHandler


### PR DESCRIPTION
# Description

Implements a backoff strategy for metrics and features endpoints based on skipping scheduled polls/posts.
Specific failed request responses (401, 403, 404, 429, 500, 502, 503, 504) increases amount of requests to skip.
10 skips in a row is maximum.
401, 403, 404 cause the skip counter to increase to 10 immediately

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Unit tests to provoke the behavior has been added

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules