### PR TITLE
feat: core switchable parallel yggdrasil engine integration

### DIFF
--- a/src/Unleash/Communication/FetchTogglesResult.cs
+++ b/src/Unleash/Communication/FetchTogglesResult.cs
@@ -7,5 +7,6 @@ namespace Unleash.Communication
         public ToggleCollection ToggleCollection { get; set; }
         public bool HasChanged { get; set; }
         public string Etag { get; set; }
+        public string ResponseContent { get; set; }
     }
 }

--- a/src/Unleash/Communication/IUnleashApiClient.cs
+++ b/src/Unleash/Communication/IUnleashApiClient.cs
@@ -1,6 +1,7 @@
 ﻿using System.Threading;
 using System.Threading.Tasks;
 using Unleash.Metrics;
+using EngineBucket = Yggdrasil.MetricsBucket;
 
 namespace Unleash.Communication
 {
@@ -9,5 +10,6 @@ namespace Unleash.Communication
         Task<FetchTogglesResult> FetchToggles(string etag, CancellationToken cancellationToken);
         Task<bool> RegisterClient(ClientRegistration registration, CancellationToken cancellationToken);
         Task<bool> SendMetrics(ThreadSafeMetricsBucket metrics, CancellationToken cancellationToken);
+        Task<bool> SendEngineMetrics(EngineBucket metrics, CancellationToken cancellationToken);
     }
 }

--- a/src/Unleash/DefaultUnleash.cs
+++ b/src/Unleash/DefaultUnleash.cs
@@ -118,11 +118,12 @@ namespace Unleash
         {
             if (settings.UseYggdrasil)
             {
-                var enabled = services.YggdrasilEngine.IsEnabled(toggleName, context) ?? defaultSetting;
+                var enhancedContext = context.ApplyStaticFields(settings);
+                var enabled = services.YggdrasilEngine.IsEnabled(toggleName, enhancedContext) ?? defaultSetting;
                 services.YggdrasilEngine.CountFeature(toggleName, enabled);
                 if (services.YggdrasilEngine.ShouldEmitImpressionEvent(toggleName))
                 {
-                    EmitImpressionEvent("isEnabled", context, enabled, toggleName);
+                    EmitImpressionEvent("isEnabled", enhancedContext, enabled, toggleName);
                 }
 
                 return enabled;
@@ -273,13 +274,13 @@ namespace Unleash
         {
             if (settings.UseYggdrasil)
             {
-                var engineVariant = services.YggdrasilEngine.GetVariant(toggleName, context);
+                var enhancedContext = context.ApplyStaticFields(settings);
+                var engineVariant = services.YggdrasilEngine.GetVariant(toggleName, enhancedContext);
                 var variant = engineVariant != null ? Variant.FromEngineVariant(engineVariant) : defaultValue;
                 services.YggdrasilEngine.CountVariant(toggleName, variant.Name);
-                context.ApplyStaticFields(settings);
                 if (services.YggdrasilEngine.ShouldEmitImpressionEvent(toggleName))
                 {
-                    EmitImpressionEvent("getVariant", context, variant.IsEnabled, toggleName, variant.Name);
+                    EmitImpressionEvent("getVariant", enhancedContext, variant.IsEnabled, toggleName, variant.Name);
                 }
 
                 return variant;

--- a/src/Unleash/Internal/BootstrapLoadResult.cs
+++ b/src/Unleash/Internal/BootstrapLoadResult.cs
@@ -1,0 +1,7 @@
+using Unleash.Internal;
+
+public class BootstrapLoadResult
+{
+    public ToggleCollection ToggleCollection { get; set; }
+    public string ToggleContent { get; set; }
+}

--- a/src/Unleash/Internal/IToggleBootstrapProvider.cs
+++ b/src/Unleash/Internal/IToggleBootstrapProvider.cs
@@ -6,6 +6,6 @@ namespace Unleash.Internal
 {
     public interface IToggleBootstrapProvider
     {
-        ToggleCollection Read();
+        BootstrapLoadResult Read();
     }
 }

--- a/src/Unleash/Internal/UnleashServices.cs
+++ b/src/Unleash/Internal/UnleashServices.cs
@@ -60,6 +60,13 @@ namespace Unleash
                 Instance = cachedFilesResult.InitialToggleCollection ?? new ToggleCollection()
             };
 
+            if (settings.UseYggdrasil &&
+                cachedFilesResult.InitialToggleCollection != null &&
+                !string.IsNullOrEmpty(cachedFilesResult.ToggleContent))
+            {
+                YggdrasilEngine.TakeState(cachedFilesResult.ToggleContent);
+            }
+
             MetricsBucket = new ThreadSafeMetricsBucket();
 
             IUnleashApiClient apiClient;

--- a/src/Unleash/Internal/Variant.cs
+++ b/src/Unleash/Internal/Variant.cs
@@ -1,4 +1,5 @@
 ﻿using Unleash.Variants;
+using YggdrasilVariant = Yggdrasil.Variant;
 
 namespace Unleash.Internal
 {
@@ -18,5 +19,13 @@ namespace Unleash.Internal
         public Payload Payload { get; }
         public bool IsEnabled { get; }
         public bool FeatureEnabled { get; internal set; }
+
+        public static Variant FromEngineVariant(YggdrasilVariant variant)
+        {
+            if (variant == null)
+                return DISABLED_VARIANT;
+
+            return new Variant(variant.Name, new Payload(variant.Payload.PayloadType, variant.Payload.Value), variant.Enabled, variant.FeatureEnabled);
+        }
     }
 }

--- a/src/Unleash/Internal/Variant.cs
+++ b/src/Unleash/Internal/Variant.cs
@@ -25,7 +25,9 @@ namespace Unleash.Internal
             if (variant == null)
                 return DISABLED_VARIANT;
 
-            return new Variant(variant.Name, new Payload(variant.Payload.PayloadType, variant.Payload.Value), variant.Enabled, variant.FeatureEnabled);
+            var payload = variant.Payload != null ? new Payload(variant.Payload.PayloadType, variant.Payload.Value) : null;
+
+            return new Variant(variant.Name, payload, variant.Enabled, variant.FeatureEnabled);
         }
     }
 }

--- a/src/Unleash/Unleash.csproj
+++ b/src/Unleash/Unleash.csproj
@@ -1,13 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+  <!--
   <PropertyGroup Condition=" '$(OS)' == 'Windows_NT' ">
     <TargetFrameworks>netstandard2.0;net48;net472;net47;net461;net46;net451;net45</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(OS)' != 'Windows_NT' ">
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
+  </PropertyGroup>-->
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
-
   <PropertyGroup>
     <RootNamespace>Unleash</RootNamespace>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
@@ -94,6 +97,7 @@
     </PackageReference>
     <PackageReference Include="murmurhash" Version="1.0.3" />
     <PackageReference Include="NuGet.Versioning" Version="6.1.0" />
+    <PackageReference Include="Yggdrasil.Engine" Version="1.0.0-alpha.1" />
   </ItemGroup>
   
   <ItemGroup>

--- a/src/Unleash/UnleashContext.cs
+++ b/src/Unleash/UnleashContext.cs
@@ -6,16 +6,8 @@ namespace Unleash
     /// <summary>
     /// A context which the feature request should be validated against. Usually scoped to a web request through an implementation of IUnleashContextProvider.
     /// </summary>
-    public class UnleashContext
+    public class UnleashContext : Yggdrasil.Context
     {
-        public string AppName { get; set; }
-        public string Environment { get; set; }
-        public string UserId { get; set; }
-        public string SessionId { get; set; }
-        public string RemoteAddress { get; set; }
-        public DateTimeOffset? CurrentTime { get; set; }
-        public Dictionary<string, string> Properties { get; set; }
-
         public UnleashContext()
         {
             Properties = new Dictionary<string, string>();

--- a/src/Unleash/UnleashSettings.cs
+++ b/src/Unleash/UnleashSettings.cs
@@ -140,6 +140,11 @@ namespace Unleash
         /// </summary>
         internal bool ScheduleFeatureToggleFetchImmediatly { get; set; } = true;
 
+        /// <summary>
+        /// Gets or sets if the unleash client should use Yggdrasil as feature flag engine.
+        /// </summary>
+        public bool UseYggdrasil { get; set; }
+
         private static string GetSdkVersion()
         {
             var assemblyName = Assembly.GetExecutingAssembly().GetName();

--- a/src/Unleash/Utilities/ToggleBootstrapFileProvider.cs
+++ b/src/Unleash/Utilities/ToggleBootstrapFileProvider.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Text;
 using Unleash.Internal;
 using Unleash.Serialization;
@@ -17,10 +18,13 @@ namespace Unleash.Utilities
             this.settings = settings;
         }
 
-        public ToggleCollection Read()
+        public BootstrapLoadResult Read()
         {
-            using (var togglesStream = settings.FileSystem.FileOpenRead(filePath))
-                return settings.JsonSerializer.Deserialize<ToggleCollection>(togglesStream);
+            var fileContent = settings.FileSystem.ReadAllText(filePath);
+            using (var togglesStream = new MemoryStream(Encoding.UTF8.GetBytes(fileContent)))
+                return new BootstrapLoadResult {
+                    ToggleCollection = settings.JsonSerializer.Deserialize<ToggleCollection>(togglesStream)
+                };
         }
     }
 }

--- a/src/Unleash/Utilities/ToggleBootstrapUrlProvider.cs
+++ b/src/Unleash/Utilities/ToggleBootstrapUrlProvider.cs
@@ -31,12 +31,12 @@ namespace Unleash.Utilities
             this.customHeaders = customHeaders;
         }
 
-        public ToggleCollection Read()
+        public BootstrapLoadResult Read()
         {
             return Task.Run(() => FetchFile()).GetAwaiter().GetResult();
         }
 
-        private async Task<ToggleCollection> FetchFile()
+        private async Task<BootstrapLoadResult> FetchFile()
         {
             using (var request = new HttpRequestMessage(HttpMethod.Get, path))
             {
@@ -63,8 +63,12 @@ namespace Unleash.Utilities
 
                     try
                     {
-                        var togglesResponseStream = await response.Content.ReadAsStreamAsync();
-                        return settings.JsonSerializer.Deserialize<ToggleCollection>(togglesResponseStream);
+                        var responseContent = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+                        var togglesResponseStream = new MemoryStream(Encoding.UTF8.GetBytes(responseContent));
+                        return new BootstrapLoadResult {
+                            ToggleCollection = settings.JsonSerializer.Deserialize<ToggleCollection>(togglesResponseStream),
+                            ToggleContent = responseContent
+                        };
                     }
                     catch (Exception ex)
                     {

--- a/tests/Unleash.Tests/IOTests.cs
+++ b/tests/Unleash.Tests/IOTests.cs
@@ -24,7 +24,7 @@ namespace Unleash.Tests
         [Test]
         public async Task GracefullyFailsWhenFileLocked()
         {
-            var settings = new MockedUnleashSettings(false);
+            var settings = new MockedUnleashSettings();
             
             var toggleFile = settings.GetFeatureToggleFilePath();
             var eTagFile = settings.GetFeatureToggleETagFilePath();

--- a/tests/Unleash.Tests/Integration/ClientSpecificationTests.cs
+++ b/tests/Unleash.Tests/Integration/ClientSpecificationTests.cs
@@ -179,8 +179,7 @@ namespace Unleash.Tests.Specifications
                 AppName = testDefinition.Name,
                 UnleashContextProvider = new DefaultUnleashContextProvider(contextBuilder.Build()),
                 HttpClientFactory = fakeHttpClientFactory,
-                ScheduledTaskManager = fakeScheduler,
-                FileSystem = fakeFileSystem
+                ScheduledTaskManager = fakeScheduler
             };
 
             var unleash = new DefaultUnleash(settings);

--- a/tests/Unleash.Tests/Internal/CachedFilesLoader_Bootstrap_Tests.cs
+++ b/tests/Unleash.Tests/Internal/CachedFilesLoader_Bootstrap_Tests.cs
@@ -13,30 +13,31 @@ namespace Unleash.Tests.Internal
 {
     public class CachedFilesLoader_Bootstrap_Tests : CachedFilesLoaderTestBase
     {
-        private static ToggleCollection GetTestToggles()
+        private static BootstrapLoadResult GetTestToggles()
         {
-            return new ToggleCollection(new List<FeatureToggle>
-            {
-                new FeatureToggle("one-enabled",  "release", true, false, new List<ActivationStrategy>()
+            return new BootstrapLoadResult { 
+                ToggleCollection = new ToggleCollection(new List<FeatureToggle>
                 {
-                    new ActivationStrategy("userWithId", new Dictionary<string, string>(){
-                        {"userIds", "userA" }
-                    })
-                }, new List<VariantDefinition>()
-                {
-                    new VariantDefinition("Aa", 33, null, null),
-                    new VariantDefinition("Aa", 33, null, null),
-                    new VariantDefinition("Ab", 34, null, new List<VariantOverride>{ new VariantOverride("context", new[] { "a", "b"}) }),
-                }
-                ),
-                new FeatureToggle("one-disabled",  "release", false, false, new List<ActivationStrategy>()
-                {
-                    new ActivationStrategy("userWithId", new Dictionary<string, string>()
+                    new FeatureToggle("one-enabled",  "release", true, false, new List<ActivationStrategy>()
                     {
-                        {"userIds", "userB" }
+                        new ActivationStrategy("userWithId", new Dictionary<string, string>(){
+                            {"userIds", "userA" }
+                        })
+                    }, new List<VariantDefinition>()
+                    {
+                        new VariantDefinition("Aa", 33, null, null),
+                        new VariantDefinition("Aa", 33, null, null),
+                        new VariantDefinition("Ab", 34, null, new List<VariantOverride>{ new VariantOverride("context", new[] { "a", "b"}) }),
+                    }
+                    ),
+                    new FeatureToggle("one-disabled",  "release", false, false, new List<ActivationStrategy>()
+                    {
+                        new ActivationStrategy("userWithId", new Dictionary<string, string>()
+                        {
+                            {"userIds", "userB" }
+                        })
                     })
-                })
-            });
+                })};
         }
 
         [Test]
@@ -72,7 +73,7 @@ namespace Unleash.Tests.Internal
             string etagFileName = AppDataFile("etag-missing.txt");
             var serializer = new JsonNetSerializer();
             var fileSystem = new FileSystem(Encoding.UTF8);
-            ToggleCollection bootstrapToggles = null;
+            BootstrapLoadResult bootstrapToggles = null;
             var bootstrapProviderFake = A.Fake<IToggleBootstrapProvider>();
             A.CallTo(() => bootstrapProviderFake.Read())
                 .Returns(bootstrapToggles);
@@ -189,7 +190,7 @@ namespace Unleash.Tests.Internal
             var settings = new UnleashSettings();
             var bootstrapProviderFake = A.Fake<IToggleBootstrapProvider>();
             A.CallTo(() => bootstrapProviderFake.Read())
-                .Returns(new ToggleCollection());
+                .Returns(new BootstrapLoadResult());
             var fileLoader = new CachedFilesLoader(serializer, fileSystem, bootstrapProviderFake, null, toggleFileName, etagFileName, true);
 
             // Act

--- a/tests/Unleash.Tests/Internal/Dependent_Features_Tests.cs
+++ b/tests/Unleash.Tests/Internal/Dependent_Features_Tests.cs
@@ -598,7 +598,6 @@ namespace Unleash.Tests.Internal
                 AppName = name,
                 HttpClientFactory = fakeHttpClientFactory,
                 ScheduledTaskManager = fakeScheduler,
-                FileSystem = fakeFileSystem
             };
 
             var unleash = new DefaultUnleash(settings);

--- a/tests/Unleash.Tests/Internal/ErrorEvents_Tests.cs
+++ b/tests/Unleash.Tests/Internal/ErrorEvents_Tests.cs
@@ -98,7 +98,7 @@ namespace Unleash.Tests.Internal
             var serializer = new DynamicNewtonsoftJsonSerializer();
             var filesystem = new MockFileSystem();
             var tokenSource = new CancellationTokenSource();
-            var task = new FetchFeatureTogglesTask(fakeApiClient, collection, serializer, filesystem, callbackConfig, "togglefile.txt", "etagfile.txt");
+            var task = new FetchFeatureTogglesTask(fakeApiClient, collection, serializer, filesystem, callbackConfig, null, "togglefile.txt", "etagfile.txt");
 
             // Act
             try
@@ -138,7 +138,7 @@ namespace Unleash.Tests.Internal
 
             var filesystem = new MockFileSystem();
             var tokenSource = new CancellationTokenSource();
-            var task = new FetchFeatureTogglesTask(fakeApiClient, collection, serializer, filesystem, callbackConfig, "togglefile.txt", "etagfile.txt");
+            var task = new FetchFeatureTogglesTask(fakeApiClient, collection, serializer, filesystem, callbackConfig, null, "togglefile.txt", "etagfile.txt");
 
             // Act
             Task.WaitAll(task.ExecuteAsync(tokenSource.Token));
@@ -173,7 +173,7 @@ namespace Unleash.Tests.Internal
                 .Throws(() => new IOException(exceptionMessage));
 
             var tokenSource = new CancellationTokenSource();
-            var task = new FetchFeatureTogglesTask(fakeApiClient, collection, serializer, filesystem, callbackConfig, "togglefile.txt", "etagfile.txt");
+            var task = new FetchFeatureTogglesTask(fakeApiClient, collection, serializer, filesystem, callbackConfig, null, "togglefile.txt", "etagfile.txt");
 
             // Act
             Task.WaitAll(task.ExecuteAsync(tokenSource.Token));

--- a/tests/Unleash.Tests/Internal/ErrorEvents_Tests.cs
+++ b/tests/Unleash.Tests/Internal/ErrorEvents_Tests.cs
@@ -29,7 +29,7 @@ namespace Unleash.Tests.Internal
         {
             // Arrange
             ErrorEvent callbackEvent = null;
-            var fakeHttpMessageHandler = new TestHttpMessageHandler()
+            var fakeHttpMessageHandler = new TestHttpMessageHandler(null)
             {
                 Response = new HttpResponseMessage(HttpStatusCode.Unauthorized) { Content = new StringContent("Unauthorized", Encoding.UTF8) },
             };
@@ -55,10 +55,7 @@ namespace Unleash.Tests.Internal
         {
             // Arrange
             ErrorEvent callbackEvent = null;
-            var fakeHttpMessageHandler = new TestHttpMessageHandler()
-            {
-                Response = new HttpResponseMessage(HttpStatusCode.Unauthorized) { Content = new StringContent("Unauthorized", Encoding.UTF8) },
-            };
+            var fakeHttpMessageHandler = new TestHttpMessageHandler(new HttpResponseMessage(HttpStatusCode.Unauthorized) { Content = new StringContent("Unauthorized", Encoding.UTF8) });
             var httpClient = new HttpClient(fakeHttpMessageHandler) { BaseAddress = new Uri("http://localhost") };
             var callbackConfig = new EventCallbackConfig()
             {

--- a/tests/Unleash.Tests/Internal/ImpressionData_Tests.cs
+++ b/tests/Unleash.Tests/Internal/ImpressionData_Tests.cs
@@ -26,15 +26,33 @@ namespace Unleash.Tests.Internal
             // Arrange
             ImpressionEvent callbackEvent = null;
             var appname = "testapp";
-            var strategy = new ActivationStrategy("default", new Dictionary<string, string>(), new List<Constraint>() { new Constraint("item-id", Operator.NUM_EQ, false, false, "1") });
-            var toggles = new List<FeatureToggle>()
+
+            var state = @"
             {
-                new FeatureToggle("item", "release", true, true, new List<ActivationStrategy>() { strategy })
-            };
-
-
-            var state = new ToggleCollection(toggles);
-            state.Version = 2;
+                ""version"": 2,
+                ""features"": [
+                    {
+                        ""name"": ""item"",
+                        ""type"": ""release"",
+                        ""enabled"": true,
+                        ""impressionData"": true,
+                        ""strategies"": [
+                            {
+                                ""name"": ""default"",
+                                ""parameters"": {},
+                                ""constraints"": [
+                                    {
+                                        ""contextName"": ""item-id"",
+                                        ""operator"": ""NUM_EQ"",
+                                        ""value"": ""1"",
+                                        ""caseInsensitive"": false,
+                                        ""inverted"": false
+                                    }
+                                ]
+                            }]
+                    }
+                ]
+            }";
             var unleash = CreateUnleash(appname, state);
             unleash.ConfigureEvents(cfg =>
             {
@@ -59,15 +77,34 @@ namespace Unleash.Tests.Internal
             // Arrange
             ImpressionEvent callbackEvent = null;
             var appname = "testapp";
-            var strategy = new ActivationStrategy("default", new Dictionary<string, string>(), new List<Constraint>() { new Constraint("item-id", Operator.NUM_EQ, false, false, "1") });
-            var toggles = new List<FeatureToggle>()
+
+            var state = @"
             {
-                new FeatureToggle("item", "release", true, false, new List<ActivationStrategy>() { strategy })
-            };
+                ""version"": 2,
+                ""features"": [
+                    {
+                        ""name"": ""item"",
+                        ""type"": ""release"",
+                        ""enabled"": true,
+                        ""impressionData"": false,
+                        ""strategies"": [
+                            {
+                                ""name"": ""default"",
+                                ""parameters"": {},
+                                ""constraints"": [
+                                    {
+                                        ""contextName"": ""item-id"",
+                                        ""operator"": ""NUM_EQ"",
+                                        ""value"": ""1"",
+                                        ""caseInsensitive"": false,
+                                        ""inverted"": false
+                                    }
+                                ]
+                            }]
+                    }
+                ]
+            }";
 
-
-            var state = new ToggleCollection(toggles);
-            state.Version = 2;
             var unleash = CreateUnleash(appname, state);
             unleash.ConfigureEvents(cfg =>
             {
@@ -88,15 +125,33 @@ namespace Unleash.Tests.Internal
         {
             // Arrange
             var appname = "testapp";
-            var strategy = new ActivationStrategy("default", new Dictionary<string, string>(), new List<Constraint>() { new Constraint("item-id", Operator.NUM_EQ, false, false, "1") });
-            var toggles = new List<FeatureToggle>()
+            var state = @"
             {
-                new FeatureToggle("item", "release", true, true, new List<ActivationStrategy>() { strategy })
-            };
+                ""version"": 2,
+                ""features"": [
+                    {
+                        ""name"": ""item"",
+                        ""type"": ""release"",
+                        ""enabled"": true,
+                        ""impressionData"": true,
+                        ""strategies"": [
+                            {
+                                ""name"": ""default"",
+                                ""parameters"": {},
+                                ""constraints"": [
+                                    {
+                                        ""contextName"": ""item-id"",
+                                        ""operator"": ""NUM_EQ"",
+                                        ""value"": ""1"",
+                                        ""caseInsensitive"": false,
+                                        ""inverted"": false
+                                    }
+                                ]
+                            }]
+                    }
+                ]
+            }";
 
-
-            var state = new ToggleCollection(toggles);
-            state.Version = 2;
             var unleash = CreateUnleash(appname, state);
             unleash.ConfigureEvents(cfg =>
             {
@@ -113,16 +168,33 @@ namespace Unleash.Tests.Internal
         {
             // Arrange
             var appname = "testapp";
-            var strategy = new ActivationStrategy("default", new Dictionary<string, string>(), new List<Constraint>() { new Constraint("item-id", Operator.NUM_EQ, false, false, "1") });
-            var toggles = new List<FeatureToggle>()
+            var state = @"
             {
-                new FeatureToggle("item", "release", true, true, new List<ActivationStrategy>() { strategy })
-            };
-
-
-            var state = new ToggleCollection(toggles);
-            state.Version = 2;
-            var unleash = CreateUnleash(appname, state);
+                ""version"": 2,
+                ""features"": [
+                    {
+                        ""name"": ""item"",
+                        ""type"": ""release"",
+                        ""enabled"": true,
+                        ""impressionData"": true,
+                        ""strategies"": [
+                            {
+                                ""name"": ""default"",
+                                ""parameters"": {},
+                                ""constraints"": [
+                                    {
+                                        ""contextName"": ""item-id"",
+                                        ""operator"": ""NUM_EQ"",
+                                        ""value"": ""1"",
+                                        ""caseInsensitive"": false,
+                                        ""inverted"": false
+                                    }
+                                ]
+                            }]
+                    }
+                ]
+            }";
+            var unleash = CreateUnleash(appname, "");//state);
             unleash.ConfigureEvents(cfg =>
             {
                 cfg.ImpressionEvent = null;
@@ -139,17 +211,45 @@ namespace Unleash.Tests.Internal
             // Arrange
             ImpressionEvent callbackEvent = null;
             var appname = "testapp";
-            var strategy = new ActivationStrategy("default", new Dictionary<string, string>(), new List<Constraint>() { new Constraint("item-id", Operator.NUM_EQ, false, false, "1") });
-            var payload = new Payload("string", "val1");
-            var variant = new VariantDefinition("blue", 100, payload);
-            var toggles = new List<FeatureToggle>()
+
+            var state = @"
             {
-                new FeatureToggle("item", "release", true, true, new List<ActivationStrategy>() { strategy }, new List<VariantDefinition>() { variant })
-            };
+                ""version"": 2,
+                ""features"": [
+                    {
+                        ""name"": ""item"",
+                        ""type"": ""release"",
+                        ""enabled"": true,
+                        ""impressionData"": true,
+                        ""strategies"": [
+                            {
+                                ""name"": ""default"",
+                                ""parameters"": {},
+                                ""constraints"": [
+                                    {
+                                        ""contextName"": ""item-id"",
+                                        ""operator"": ""NUM_EQ"",
+                                        ""value"": ""1"",
+                                        ""caseInsensitive"": false,
+                                        ""inverted"": false
+                                    }
+                                ]
+                            }],
+                        ""variants"": [
+                            {
+                                ""name"": ""blue"",
+                                ""weight"": 100,
+                                ""payload"": {
+                                    ""type"": ""string"",
+                                    ""value"": ""val1""
+                                }
+                            }
+                        ]
+                    }
+                ]
+            }";
 
 
-            var state = new ToggleCollection(toggles);
-            state.Version = 2;
             var unleash = CreateUnleash(appname, state);
             unleash.ConfigureEvents(cfg =>
             {
@@ -173,16 +273,34 @@ namespace Unleash.Tests.Internal
         {
             // Arrange
             var appname = "testapp";
-            var strategy = new ActivationStrategy("default", new Dictionary<string, string>(), new List<Constraint>() { new Constraint("item-id", Operator.NUM_EQ, false, false, "1") });
-            var payload = new Payload("string", "val1");
-            var toggles = new List<FeatureToggle>()
+
+            var state = @"
             {
-                new FeatureToggle("yup", "release", true, true, new List<ActivationStrategy>() { strategy })
-            };
+                ""version"": 2,
+                ""features"": [
+                    {
+                        ""name"": ""yup"",
+                        ""type"": ""release"",
+                        ""enabled"": true,
+                        ""impressionData"": false,
+                        ""strategies"": [
+                            {
+                                ""name"": ""default"",
+                                ""parameters"": {},
+                                ""constraints"": [
+                                    {
+                                        ""contextName"": ""item-id"",
+                                        ""operator"": ""NUM_EQ"",
+                                        ""value"": ""1"",
+                                        ""caseInsensitive"": false,
+                                        ""inverted"": false
+                                    }
+                                ]
+                            }]
+                    }
+                ]
+            }";
 
-
-            var state = new ToggleCollection(toggles);
-            state.Version = 2;
             var unleash = CreateUnleash(appname, state);
 
             // Act
@@ -193,14 +311,20 @@ namespace Unleash.Tests.Internal
             enabled.Should().BeTrue();
         }
 
-        public static IUnleash CreateUnleash(string name, ToggleCollection state)
+        public static IUnleash CreateUnleash(string name, string state)
         {
             var fakeHttpClientFactory = A.Fake<IHttpClientFactory>();
-            var fakeHttpMessageHandler = new TestHttpMessageHandler();
+            var fakeHttpMessageHandler = new TestHttpMessageHandler(new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent(state, Encoding.UTF8, "application/json"),
+                Headers =
+                {
+                    ETag = new EntityTagHeaderValue("\"123\"")
+                }
+            });
             var httpClient = new HttpClient(fakeHttpMessageHandler) { BaseAddress = new Uri("http://localhost") };
             var fakeScheduler = A.Fake<IUnleashScheduledTaskManager>();
-            var fakeFileSystem = new MockFileSystem();
-            var toggleState = Newtonsoft.Json.JsonConvert.SerializeObject(state);
 
             A.CallTo(() => fakeHttpClientFactory.Create(A<Uri>._)).Returns(httpClient);
             A.CallTo(() => fakeScheduler.Configure(A<IEnumerable<IUnleashScheduledTask>>._, A<CancellationToken>._)).Invokes(action =>
@@ -208,16 +332,6 @@ namespace Unleash.Tests.Internal
                 var task = ((IEnumerable<IUnleashScheduledTask>)action.Arguments[0]).First();
                 task.ExecuteAsync((CancellationToken)action.Arguments[1]).Wait();
             });
-
-            fakeHttpMessageHandler.Response = new HttpResponseMessage
-            {
-                StatusCode = HttpStatusCode.OK,
-                Content = new StringContent(toggleState, Encoding.UTF8, "application/json"),
-                Headers =
-                {
-                    ETag = new EntityTagHeaderValue("\"123\"")
-                }
-            };
 
             var contextBuilder = new UnleashContext.Builder();
             contextBuilder.AddProperty("item-id", "1");
@@ -228,7 +342,7 @@ namespace Unleash.Tests.Internal
                 UnleashContextProvider = new DefaultUnleashContextProvider(contextBuilder.Build()),
                 HttpClientFactory = fakeHttpClientFactory,
                 ScheduledTaskManager = fakeScheduler,
-                FileSystem = fakeFileSystem
+                UseYggdrasil = true
             };
 
             var unleash = new DefaultUnleash(settings);

--- a/tests/Unleash.Tests/Internal/TogglesUpdatedEvent_Tests.cs
+++ b/tests/Unleash.Tests/Internal/TogglesUpdatedEvent_Tests.cs
@@ -35,7 +35,7 @@ namespace Unleash.Tests.Internal
 
             var filesystem = new MockFileSystem();
             var tokenSource = new CancellationTokenSource();
-            var task = new FetchFeatureTogglesTask(fakeApiClient, collection, serializer, filesystem, callbackConfig, "togglefile.txt", "etagfile.txt");
+            var task = new FetchFeatureTogglesTask(fakeApiClient, collection, serializer, filesystem, callbackConfig, null, "togglefile.txt", "etagfile.txt");
 
             // Act
             Task.WaitAll(task.ExecuteAsync(tokenSource.Token));
@@ -64,7 +64,7 @@ namespace Unleash.Tests.Internal
 
             var filesystem = new MockFileSystem();
             var tokenSource = new CancellationTokenSource();
-            var task = new FetchFeatureTogglesTask(fakeApiClient, collection, serializer, filesystem, callbackConfig, "togglefile.txt", "etagfile.txt");
+            var task = new FetchFeatureTogglesTask(fakeApiClient, collection, serializer, filesystem, callbackConfig, null, "togglefile.txt", "etagfile.txt");
 
             // Act
             Task.WaitAll(task.ExecuteAsync(tokenSource.Token));
@@ -100,7 +100,7 @@ namespace Unleash.Tests.Internal
 
             var filesystem = new MockFileSystem();
             var tokenSource = new CancellationTokenSource();
-            var task = new FetchFeatureTogglesTask(fakeApiClient, toggleCollection, serializer, filesystem, callbackConfig, "togglefile.txt", "etagfile.txt");
+            var task = new FetchFeatureTogglesTask(fakeApiClient, toggleCollection, serializer, filesystem, callbackConfig, null, "togglefile.txt", "etagfile.txt");
 
             // Act
             Task.WaitAll(task.ExecuteAsync(tokenSource.Token));

--- a/tests/Unleash.Tests/Mock/MockApiClient.cs
+++ b/tests/Unleash.Tests/Mock/MockApiClient.cs
@@ -5,6 +5,7 @@ using Unleash.Communication;
 using Unleash.Internal;
 using Unleash.Metrics;
 using Unleash.Variants;
+using EngineBucket = Yggdrasil.MetricsBucket;
 
 namespace Unleash.Tests.Mock
 {
@@ -53,6 +54,11 @@ namespace Unleash.Tests.Mock
         }
 
         public Task<bool> SendMetrics(ThreadSafeMetricsBucket metricsBucket, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(true);
+        }
+
+        public Task<bool> SendEngineMetrics(EngineBucket metricsBucket, CancellationToken cancellationToken)
         {
             return Task.FromResult(true);
         }

--- a/tests/Unleash.Tests/MockedUnleashSettings.cs
+++ b/tests/Unleash.Tests/MockedUnleashSettings.cs
@@ -8,19 +8,14 @@ namespace Unleash.Tests
 {
     public class MockedUnleashSettings : UnleashSettings
     {
-        public MockedUnleashSettings(bool mockFileSystem = true)
+        public MockedUnleashSettings()
         {
             AppName = "test";
-            InstanceTag = "test instance 1";
             UnleashApi = new Uri("http://localhost:4242/");
 
             UnleashApiClient = new MockApiClient();
-            FileSystem = new MockFileSystem();
             
-            if (!mockFileSystem)
-            {
-                FileSystem = new FileSystem(Encoding.UTF8);
-            }
+            FileSystem = new FileSystem(Encoding.UTF8);
 
             UnleashContextProvider = new DefaultUnleashContextProvider(new UnleashContext
             {

--- a/tests/Unleash.Tests/Strategy/Segments_Tests.cs
+++ b/tests/Unleash.Tests/Strategy/Segments_Tests.cs
@@ -109,7 +109,6 @@ namespace Unleash.Tests.Strategy.Segments
             });
             var httpClient = new HttpClient(fakeHttpMessageHandler) { BaseAddress = new Uri("http://localhost") };
             var fakeScheduler = A.Fake<IUnleashScheduledTaskManager>();
-            var fakeFileSystem = new MockFileSystem();
 
             A.CallTo(() => fakeHttpClientFactory.Create(A<Uri>._)).Returns(httpClient);
             A.CallTo(() => fakeScheduler.Configure(A<IEnumerable<IUnleashScheduledTask>>._, A<CancellationToken>._)).Invokes(action =>
@@ -126,8 +125,7 @@ namespace Unleash.Tests.Strategy.Segments
                 AppName = name,
                 UnleashContextProvider = new DefaultUnleashContextProvider(contextBuilder.Build()),
                 HttpClientFactory = fakeHttpClientFactory,
-                ScheduledTaskManager = fakeScheduler,
-                FileSystem = fakeFileSystem
+                ScheduledTaskManager = fakeScheduler
             };
 
             var unleash = new DefaultUnleash(settings);

--- a/tests/Unleash.Tests/Strategy/Segments_Tests.cs
+++ b/tests/Unleash.Tests/Strategy/Segments_Tests.cs
@@ -97,20 +97,8 @@ namespace Unleash.Tests.Strategy.Segments
         public static IUnleash CreateUnleash(string name, ToggleCollection state)
         {
             var fakeHttpClientFactory = A.Fake<IHttpClientFactory>();
-            var fakeHttpMessageHandler = new TestHttpMessageHandler();
-            var httpClient = new HttpClient(fakeHttpMessageHandler) { BaseAddress = new Uri("http://localhost") };
-            var fakeScheduler = A.Fake<IUnleashScheduledTaskManager>();
-            var fakeFileSystem = new MockFileSystem();
             var toggleState = Newtonsoft.Json.JsonConvert.SerializeObject(state);
-
-            A.CallTo(() => fakeHttpClientFactory.Create(A<Uri>._)).Returns(httpClient);
-            A.CallTo(() => fakeScheduler.Configure(A<IEnumerable<IUnleashScheduledTask>>._, A<CancellationToken>._)).Invokes(action =>
-            {
-                var task = ((IEnumerable<IUnleashScheduledTask>)action.Arguments[0]).First();
-                task.ExecuteAsync((CancellationToken)action.Arguments[1]).Wait();
-            });
-
-            fakeHttpMessageHandler.Response = new HttpResponseMessage
+            var fakeHttpMessageHandler = new TestHttpMessageHandler(new HttpResponseMessage
             {
                 StatusCode = HttpStatusCode.OK,
                 Content = new StringContent(toggleState, Encoding.UTF8, "application/json"),
@@ -118,7 +106,17 @@ namespace Unleash.Tests.Strategy.Segments
                 {
                     ETag = new EntityTagHeaderValue("\"123\"")
                 }
-            };
+            });
+            var httpClient = new HttpClient(fakeHttpMessageHandler) { BaseAddress = new Uri("http://localhost") };
+            var fakeScheduler = A.Fake<IUnleashScheduledTaskManager>();
+            var fakeFileSystem = new MockFileSystem();
+
+            A.CallTo(() => fakeHttpClientFactory.Create(A<Uri>._)).Returns(httpClient);
+            A.CallTo(() => fakeScheduler.Configure(A<IEnumerable<IUnleashScheduledTask>>._, A<CancellationToken>._)).Invokes(action =>
+            {
+                var task = ((IEnumerable<IUnleashScheduledTask>)action.Arguments[0]).First();
+                task.ExecuteAsync((CancellationToken)action.Arguments[1]).Wait();
+            });
 
             var contextBuilder = new UnleashContext.Builder();
             contextBuilder.AddProperty("item-id", "1");

--- a/tests/Unleash.Tests/Unleash.Tests.csproj
+++ b/tests/Unleash.Tests/Unleash.Tests.csproj
@@ -21,6 +21,7 @@
     <PackageReference Include="NLog" Version="5.2.0" />
     <PackageReference Include="NLog.Config" Version="4.7.15" />
     <PackageReference Include="NLog.Schema" Version="5.2.0" />
+    <PackageReference Include="Yggdrasil.Engine" Version="1.0.0-alpha.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Unleash.Tests/Utilities/ToggleBootstrapFileProvider_Tests.cs
+++ b/tests/Unleash.Tests/Utilities/ToggleBootstrapFileProvider_Tests.cs
@@ -33,7 +33,7 @@ namespace Unleash.Tests.Utilities
             var emptyResult = toggleFileProvider.Read();
 
             // Assert
-            emptyResult.Should().BeNull();
+            emptyResult.ToggleCollection.Should().BeNull();
         }
 
         [Test]
@@ -49,8 +49,8 @@ namespace Unleash.Tests.Utilities
             var result = toggleFileProvider.Read();
 
             // Assert
-            result.Features.Count().Should().Be(3);
-            result.Features.Single(f => f.Name == "featureY").Enabled.Should().Be(false);
+            result.ToggleCollection.Features.Count().Should().Be(3);
+            result.ToggleCollection.Features.Single(f => f.Name == "featureY").Enabled.Should().Be(false);
         }
 
         [Test]
@@ -72,8 +72,8 @@ namespace Unleash.Tests.Utilities
             var result = settings.ToggleBootstrapProvider.Read();
 
             // Assert
-            result.Features.Count().Should().Be(3);
-            result.Features.Single(f => f.Name == "featureY").Enabled.Should().Be(false);
+            result.ToggleCollection.Features.Count().Should().Be(3);
+            result.ToggleCollection.Features.Single(f => f.Name == "featureY").Enabled.Should().Be(false);
         }
     }
 }

--- a/tests/Unleash.Tests/Utilities/ToggleBootstrapUrlProvider_Tests.cs
+++ b/tests/Unleash.Tests/Utilities/ToggleBootstrapUrlProvider_Tests.cs
@@ -36,7 +36,7 @@ namespace Unleash.Tests.Utilities
             var responseContent = bootstrapUrlProvider.Read();
 
             // Assert
-            responseContent.Features.Should().BeEmpty();
+            responseContent.ToggleCollection.Features.Should().BeEmpty();
             messageHandlerMock.SentMessages.First().Method.Should().Be(HttpMethod.Get);
             messageHandlerMock.SentMessages.First().RequestUri.ToString().Should().Be(path);
         }
@@ -69,7 +69,7 @@ namespace Unleash.Tests.Utilities
             var responseContent = settings.ToggleBootstrapProvider.Read();
 
             // Assert
-            responseContent.Features.Should().BeEmpty();
+            responseContent.ToggleCollection.Features.Should().BeEmpty();
             messageHandlerMock.SentMessages.First().Method.Should().Be(HttpMethod.Get);
             messageHandlerMock.SentMessages.First().RequestUri.ToString().Should().Be(path);
         }
@@ -133,7 +133,7 @@ namespace Unleash.Tests.Utilities
 
             // Assert
             var configuredHeader = customHeaders.First();
-            responseContent.Features.Should().BeEmpty();
+            responseContent.ToggleCollection.Features.Should().BeEmpty();
             messageHandlerMock.SentMessages.First().Method.Should().Be(HttpMethod.Get);
             messageHandlerMock.SentMessages.First().RequestUri.ToString().Should().Be(path);
             messageHandlerMock.SentMessages.First().Headers.Any(kvp => kvp.Key == configuredHeader.Key && kvp.Value.First() == configuredHeader.Value).Should().BeTrue();

--- a/tests/Unleash.Tests/Variants/StrategyVariantTests.cs
+++ b/tests/Unleash.Tests/Variants/StrategyVariantTests.cs
@@ -259,7 +259,6 @@ namespace Unleash.Tests.Variants
             });
             var httpClient = new HttpClient(fakeHttpMessageHandler) { BaseAddress = new Uri("http://localhost") };
             var fakeScheduler = A.Fake<IUnleashScheduledTaskManager>();
-            var fakeFileSystem = new MockFileSystem();
 
             A.CallTo(() => fakeHttpClientFactory.Create(A<Uri>._)).Returns(httpClient);
             A.CallTo(() => fakeScheduler.Configure(A<IEnumerable<IUnleashScheduledTask>>._, A<CancellationToken>._)).Invokes(action =>
@@ -277,7 +276,6 @@ namespace Unleash.Tests.Variants
                 UnleashContextProvider = new DefaultUnleashContextProvider(contextBuilder.Build()),
                 HttpClientFactory = fakeHttpClientFactory,
                 ScheduledTaskManager = fakeScheduler,
-                FileSystem = fakeFileSystem
             };
 
             var unleash = new DefaultUnleash(settings);

--- a/tests/Unleash.Tests/Variants/StrategyVariantTests.cs
+++ b/tests/Unleash.Tests/Variants/StrategyVariantTests.cs
@@ -246,21 +246,9 @@ namespace Unleash.Tests.Variants
         public static IUnleash CreateUnleash(ToggleCollection state)
         {
             var name = "test";
-            var fakeHttpClientFactory = A.Fake<IHttpClientFactory>();
-            var fakeHttpMessageHandler = new TestHttpMessageHandler();
-            var httpClient = new HttpClient(fakeHttpMessageHandler) { BaseAddress = new Uri("http://localhost") };
-            var fakeScheduler = A.Fake<IUnleashScheduledTaskManager>();
-            var fakeFileSystem = new MockFileSystem();
             var toggleState = Newtonsoft.Json.JsonConvert.SerializeObject(state);
-
-            A.CallTo(() => fakeHttpClientFactory.Create(A<Uri>._)).Returns(httpClient);
-            A.CallTo(() => fakeScheduler.Configure(A<IEnumerable<IUnleashScheduledTask>>._, A<CancellationToken>._)).Invokes(action =>
-            {
-                var task = ((IEnumerable<IUnleashScheduledTask>)action.Arguments[0]).First();
-                task.ExecuteAsync((CancellationToken)action.Arguments[1]).Wait();
-            });
-
-            fakeHttpMessageHandler.Response = new HttpResponseMessage
+            var fakeHttpClientFactory = A.Fake<IHttpClientFactory>();
+            var fakeHttpMessageHandler = new TestHttpMessageHandler(new HttpResponseMessage
             {
                 StatusCode = HttpStatusCode.OK,
                 Content = new StringContent(toggleState, Encoding.UTF8, "application/json"),
@@ -268,7 +256,17 @@ namespace Unleash.Tests.Variants
                 {
                     ETag = new EntityTagHeaderValue("\"123\"")
                 }
-            };
+            });
+            var httpClient = new HttpClient(fakeHttpMessageHandler) { BaseAddress = new Uri("http://localhost") };
+            var fakeScheduler = A.Fake<IUnleashScheduledTaskManager>();
+            var fakeFileSystem = new MockFileSystem();
+
+            A.CallTo(() => fakeHttpClientFactory.Create(A<Uri>._)).Returns(httpClient);
+            A.CallTo(() => fakeScheduler.Configure(A<IEnumerable<IUnleashScheduledTask>>._, A<CancellationToken>._)).Invokes(action =>
+            {
+                var task = ((IEnumerable<IUnleashScheduledTask>)action.Arguments[0]).First();
+                task.ExecuteAsync((CancellationToken)action.Arguments[1]).Wait();
+            });
 
             var contextBuilder = new UnleashContext.Builder();
             contextBuilder.AddProperty("item-id", "1");

--- a/tests/Unleash.Tests/Variants/VariantsTests.cs
+++ b/tests/Unleash.Tests/Variants/VariantsTests.cs
@@ -62,18 +62,18 @@ namespace Unleash.Tests.Variants
                 AppName = "testapp",
                 UnleashApi = new Uri("http://localhost:8080/"),
                 ScheduledTaskManager = A.Fake<IUnleashScheduledTaskManager>(),
-                HttpClientFactory = fakeHttpClientFactory
+                HttpClientFactory = fakeHttpClientFactory,
+                UseYggdrasil = true
             };
             var responseContent = TestData;
-            var fakeHttpMessageHandler = new TestHttpMessageHandler();
-            fakeHttpMessageHandler.Response = new HttpResponseMessage() {
+            var fakeHttpMessageHandler = new TestHttpMessageHandler(new HttpResponseMessage() {
                 StatusCode = System.Net.HttpStatusCode.OK,
                 Content = new StringContent(responseContent, Encoding.UTF8, "application/json"),
                 Headers =
                 {
                     ETag = new EntityTagHeaderValue("\"123\"")
                 }
-            };
+            });
             var client = new HttpClient(fakeHttpMessageHandler);
             client.BaseAddress = settings.UnleashApi;
             var factory = new UnleashClientFactory();
@@ -86,16 +86,16 @@ namespace Unleash.Tests.Variants
             ""features"": [
                 {
                     ""name"": ""enabled.with.variants"",
-                    ""description"": ""Test"",
+                    ""type"": ""experimental"",
                     ""enabled"": true,
+                    ""impressionData"": false,
                     ""strategies"": [
                         {
                             ""name"": ""flexibleRollout"",
                             ""parameters"": {
-                                ""rollout"": ""100"",
-                                ""stickiness"": ""default"",
-                                ""groupId"": ""default"",
-                            }
+                                ""rollout"": ""100""
+                            },
+                            ""constraints"": []
                         }
                     ],
                     ""variants"": [
@@ -116,6 +116,8 @@ namespace Unleash.Tests.Variants
                     ""strategies"": [
                         {
                             ""name"": ""default"",
+                            ""parameters"": {},
+                            ""constraints"": []
                         }
                     ]
                 }


### PR DESCRIPTION
# Description

This is a port of the core parts of `feat/yggdrasil` made parallel/switchable, so we can have either engine depending on choices made in UnleashSettings.

All current tests are passing as the engine defaults to off. will port tests that test the integration properly.
Build should currently fail due to missing nuget dependency Yggdrasil.Engine.

I've introduced a base-branch for Yggdrasil development that this PR is aimed at - named `yggdrasil`