### PR TITLE
chore: init encoding with false for utf8 bom

### DIFF
--- a/src/Unleash/Serialization/DynamicNewtonsoftJsonSerializer.cs
+++ b/src/Unleash/Serialization/DynamicNewtonsoftJsonSerializer.cs
@@ -8,7 +8,7 @@ namespace Unleash.Serialization
     {
         public string NugetPackageName => "Newtonsoft.Json (>= 9.0.1)";
 
-        private readonly Encoding encoding = Encoding.UTF8;
+        private readonly Encoding encoding = new UTF8Encoding(false);
 
         private Type jsonTextWriterType;
         private Type jsonTextReaderType;


### PR DESCRIPTION
# Description

Fixes edge compatibility issues by disabling BOM in utf8 strings when serialized

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Local testing against edge and Unleash

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules