### PR TITLE
Improve SelectVariant performance

### DIFF
--- a/src/Unleash/Variants/VariantUtils.cs
+++ b/src/Unleash/Variants/VariantUtils.cs
@@ -12,28 +12,30 @@ namespace Unleash.Variants
 
         public static Variant SelectVariant(string groupId, UnleashContext context, List<VariantDefinition> variantDefinitions)
         {
-            var stickiness = variantDefinitions[0].Stickiness ?? "default";
+            var stickiness = variantDefinitions.FirstOrDefault()?.Stickiness ?? "default";
             var target = StrategyUtils.GetNormalizedNumber(GetIdentifier(context, stickiness), groupId, VARIANT_NORMALIZATION_SEED);
 
             var counter = 0;
+            Variant result = null;
             foreach (var variantDefinition in variantDefinitions)
             {
                 if (variantDefinition.Weight != 0)
                 {
                     if (variantDefinition.Overrides.Count > 0 && variantDefinition.Overrides.Any(OverrideMatchesContext(context)))
                     {
-                        return variantDefinition.ToVariant();
+                        result = variantDefinition.ToVariant();
+                        break;
                     }
 
                     counter += variantDefinition.Weight;
-                    if (counter >= target)
+                    if (counter >= target && result == null)
                     {
-                        return variantDefinition.ToVariant();
+                        result = variantDefinition.ToVariant();
                     }
                 }
             }
 
-            return null;
+            return result;
         }
 
         public static Variant SelectVariant(FeatureToggle feature, UnleashContext context, Variant defaultVariant = null)

--- a/src/Unleash/Variants/VariantUtils.cs
+++ b/src/Unleash/Variants/VariantUtils.cs
@@ -12,8 +12,15 @@ namespace Unleash.Variants
 
         public static Variant SelectVariant(string groupId, UnleashContext context, List<VariantDefinition> variantDefinitions)
         {
+            var totalWeight = variantDefinitions.Sum(v => v.Weight);
+
+            if (totalWeight == 0)
+            {
+                return null;
+            }
+
             var stickiness = variantDefinitions.FirstOrDefault()?.Stickiness ?? "default";
-            var target = StrategyUtils.GetNormalizedNumber(GetIdentifier(context, stickiness), groupId, VARIANT_NORMALIZATION_SEED);
+            var target = StrategyUtils.GetNormalizedNumber(GetIdentifier(context, stickiness), groupId, VARIANT_NORMALIZATION_SEED, totalWeight);
 
             var counter = 0;
             Variant result = null;


### PR DESCRIPTION
# Description
In continuing to look for performance hotspots after the latest release, `VariantUtils.SelectVariant` was identified as an area for improvement.

In the PR three changes were made to improve performance:

- totalWeight was not needed, per the docs this will always be 100%. This removes the Sum call which loops over the list of variants.
- The FirstOrDefault call was removed, this allows for us to loop over the list of variants only once.
- We check if there are any overrides before calling Any.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Using `BenchmarkerDotNet` the following benchmarks were run:

```csharp
[MemoryDiagnoser]
public class BenchmarksNoOverride
{
    readonly ActivationStrategy defaultStrategy = new ActivationStrategy("default", new Dictionary<string, string>());

    readonly FeatureToggle toggle;
    readonly UnleashContext context;

    public BenchmarksNoOverride()
    {
        var variantOverride = new VariantOverride("userId", "11", "12", "123", "44");
        var v1 = new VariantDefinition("a", 33, new Payload("string", "asd"), new List<VariantOverride>());
        var v2 = new VariantDefinition("b", 33);
        var v3 = new VariantDefinition("c", 34);
        var vOverride = new VariantDefinition("a", 33, new Payload("string", "asd"), new List<VariantOverride> {variantOverride});
        toggle = new FeatureToggle(
                    "test.variants",
                    "release",
                    true,
                    false,
                    new List<ActivationStrategy> { defaultStrategy },
                    new List<VariantDefinition> { v1, v2, v3 });

        context = new UnleashContext
        {
            UserId = "11",
            SessionId = "sessionId",
            RemoteAddress = "remoteAddress",
            Properties = new Dictionary<string, string>()
        };
    }

    [Benchmark(Baseline = true)]
    public Variant Current() => VariantUtils.SelectVariant(toggle.Name, context, toggle.Variants);

    [Benchmark]
    public Variant New() => VariantUtils.SelectVariantNew(toggle.Name, context, toggle.Variants);
}

[MemoryDiagnoser]
public class BenchmarksWithOverride
{
    readonly ActivationStrategy defaultStrategy = new ActivationStrategy("default", new Dictionary<string, string>());

    readonly FeatureToggle toggle;
    readonly UnleashContext context;

    public BenchmarksWithOverride()
    {
        var variantOverride = new VariantOverride("userId", "11", "12", "123", "44");
        var v1 = new VariantDefinition("a", 33, new Payload("string", "asd"), new List<VariantOverride>());
        var v2 = new VariantDefinition("b", 33);
        var v3 = new VariantDefinition("c", 34, null, new List<VariantOverride> { variantOverride });
        toggle = new FeatureToggle(
                    "test.variants",
                    "release",
                    true,
                    false,
                    new List<ActivationStrategy> { defaultStrategy },
                    new List<VariantDefinition> { v1, v2, v3 });

        context = new UnleashContext
        {
            UserId = "11",
            SessionId = "sessionId",
            RemoteAddress = "remoteAddress",
            Properties = new Dictionary<string, string>()
        };
    }

    [Benchmark(Baseline = true)]
    public Variant Current() => VariantUtils.SelectVariant(toggle.Name, context, toggle.Variants);

    [Benchmark]
    public Variant New() => VariantUtils.SelectVariantNew(toggle.Name, context, toggle.Variants);
}
```
These produced the following results:
### Benchmarks with no VariantOverride
 Method  | Mean     | Error   | StdDev  | Ratio | Gen0   | Allocated | Alloc Ratio |
-------- |---------:|--------:|--------:|------:|-------:|----------:|------------:|
 Current | 345.7 ns | 3.06 ns | 2.39 ns |  1.00 | 0.0634 |     800 B |        1.00 |
 New     | 129.4 ns | 2.61 ns | 3.11 ns |  0.38 | 0.0196 |     248 B |        0.31 |

### Benchmarks with a VariantOverride
Method  | Mean     | Error   | StdDev  | Ratio | Gen0   | Allocated | Alloc Ratio |
-------- |---------:|--------:|--------:|------:|-------:|----------:|------------:|
 Current | 258.7 ns | 5.12 ns | 5.26 ns |  1.00 | 0.0467 |     592 B |        1.00 |
 New     | 123.7 ns | 2.30 ns | 2.15 ns |  0.48 | 0.0196 |     248 B |        0.42 |

In both cases the new code uses less CPU and memory.