### PR TITLE
Logger Improvements

### DIFF
--- a/src/Unleash/Communication/UnleashApiClient.cs
+++ b/src/Unleash/Communication/UnleashApiClient.cs
@@ -28,14 +28,14 @@ namespace Unleash.Communication
         private int featureRequestsSkipped = 0;
         private int metricsRequestsToSkip = 0;
         private int metricsRequestsSkipped = 0;
-        private readonly int[] backoffResponses = 
+        private readonly int[] backoffResponses =
             new int[]
                 {
                     429,
                     500,
                     502,
                     503,
-                    504                 
+                    504
                 };
         private readonly int[] configurationErrorResponses =
             new int[]
@@ -45,8 +45,8 @@ namespace Unleash.Communication
                     404,
                 };
         public UnleashApiClient(
-            HttpClient httpClient, 
-            IJsonSerializer jsonSerializer, 
+            HttpClient httpClient,
+            IJsonSerializer jsonSerializer,
             UnleashApiClientRequestHeaders clientRequestHeaders,
             EventCallbackConfig eventConfig,
             string projectId = null)
@@ -108,7 +108,7 @@ namespace Unleash.Communication
             }
 
             var error = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
-            Logger.Trace($"UNLEASH: Error {response.StatusCode} from server in '{nameof(FetchToggles)}': " + error);
+            Logger.Trace(() => $"UNLEASH: Error {response.StatusCode} from server in '{nameof(FetchToggles)}': " + error);
             eventConfig?.RaiseError(new ErrorEvent() { ErrorType = ErrorType.Client, StatusCode = response.StatusCode, Resource = resourceUri });
 
             return new FetchTogglesResult
@@ -120,7 +120,7 @@ namespace Unleash.Communication
         private void Backoff(HttpResponseMessage response)
         {
             featureRequestsToSkip = Math.Min(10, featureRequestsToSkip + 1);
-            Logger.Warn($"UNLEASH: Backing off due to {response.StatusCode} from server in '{nameof(FetchToggles)}'.");
+            Logger.Warn(() => $"UNLEASH: Backing off due to {response.StatusCode} from server in '{nameof(FetchToggles)}'.");
         }
 
         private void ConfigurationError(HttpResponseMessage response, string requestUri)
@@ -129,15 +129,15 @@ namespace Unleash.Communication
 
             if (response.StatusCode == HttpStatusCode.NotFound)
             {
-                Logger.Error($"UNLEASH: Error when fetching toggles, {requestUri} responded NOT_FOUND (404) which means your API url most likely needs correction.'.");
+                Logger.Error(() => $"UNLEASH: Error when fetching toggles, {requestUri} responded NOT_FOUND (404) which means your API url most likely needs correction.'.");
             }
             else if (response.StatusCode == HttpStatusCode.Unauthorized || response.StatusCode == HttpStatusCode.Forbidden)
             {
-                Logger.Error($"UNLEASH: Error when fetching toggles, {requestUri} responded FORBIDDEN (403) which means your API token is not valid.");
+                Logger.Error(() => $"UNLEASH: Error when fetching toggles, {requestUri} responded FORBIDDEN (403) which means your API token is not valid.");
             }
             else
             {
-                Logger.Error($"UNLEASH: Configuration error due to {response.StatusCode} from server in '{nameof(FetchToggles)}'.");
+                Logger.Error(() => $"UNLEASH: Configuration error due to {response.StatusCode} from server in '{nameof(FetchToggles)}'.");
             }
         }
 
@@ -147,7 +147,7 @@ namespace Unleash.Communication
 
             var newEtag = response.Headers.ETag?.Tag;
             if (newEtag == etag)
-            { 
+            {
                 return new FetchTogglesResult
                 {
                     HasChanged = false,
@@ -198,7 +198,7 @@ namespace Unleash.Communication
                         return true;
 
                     var error = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    Logger.Trace($"UNLEASH: Error {response.StatusCode} from request '{requestUri}' in '{nameof(UnleashApiClient)}': " + error);
+                    Logger.Trace(() => $"UNLEASH: Error {response.StatusCode} from request '{requestUri}' in '{nameof(UnleashApiClient)}': " + error);
                     eventConfig?.RaiseError(new ErrorEvent() { Resource = requestUri, ErrorType = ErrorType.Client, StatusCode = response.StatusCode });
 
                     return false;
@@ -266,7 +266,7 @@ namespace Unleash.Communication
             }
 
             var error = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
-            Logger.Trace($"UNLEASH: Error {response.StatusCode} from request '{requestUri}' in '{nameof(UnleashApiClient)}': " + error);
+            Logger.Trace(() => $"UNLEASH: Error {response.StatusCode} from request '{requestUri}' in '{nameof(UnleashApiClient)}': " + error);
             eventConfig?.RaiseError(new ErrorEvent() { Resource = requestUri, ErrorType = ErrorType.Client, StatusCode = response.StatusCode });
         }
 

--- a/src/Unleash/DefaultUnleash.cs
+++ b/src/Unleash/DefaultUnleash.cs
@@ -143,7 +143,8 @@ namespace Unleash
             strategy = null;
             if (featureToggle == null)
             {
-                Logger.Warn($"UNLEASH: Feature flag {toggleName} not present, returning default setting: {defaultSetting}");
+                Logger.Warn(() => $"UNLEASH: Feature flag {toggleName} not present, returning default setting: {defaultSetting}");
+
                 return defaultSetting;
             }
 

--- a/src/Unleash/DefaultUnleash.cs
+++ b/src/Unleash/DefaultUnleash.cs
@@ -72,12 +72,12 @@ namespace Unleash
 
             services = new UnleashServices(settings, EventConfig, strategyMap);
 
-            Logger.Info($"UNLEASH: Unleash instance number { currentInstanceNo } is initialized and configured with: {settings}");
+            Logger.Info(() => $"UNLEASH: Unleash instance number { currentInstanceNo } is initialized and configured with: {settings}");
 
             if (currentInstanceNo >= ErrorOnInstanceCount)
             {
-                Logger.Error($"UNLEASH: Unleash instance count for this process is now {currentInstanceNo}.");
-                Logger.Error("Ideally you should only need 1 instance of Unleash per app/process, we strongly recommend setting up Unleash as a singleton.");
+                Logger.Error(() => $"UNLEASH: Unleash instance count for this process is now {currentInstanceNo}.");
+                Logger.Error(() => "Ideally you should only need 1 instance of Unleash per app/process, we strongly recommend setting up Unleash as a singleton.");
             }
         }
 
@@ -356,7 +356,7 @@ namespace Unleash
         {
             if (callback == null)
             {
-                Logger.Error($"UNLEASH: Unleash->ConfigureEvents parameter callback is null");
+                Logger.Error(() => $"UNLEASH: Unleash->ConfigureEvents parameter callback is null");
                 return;
             }
 
@@ -366,7 +366,7 @@ namespace Unleash
             }
             catch (Exception ex)
             {
-                Logger.Error($"UNLEASH: Unleash->ConfigureEvents executing callback threw exception: {ex.Message}");
+                Logger.Error(() => $"UNLEASH: Unleash->ConfigureEvents executing callback threw exception: {ex.Message}");
             }
         }
 
@@ -374,7 +374,7 @@ namespace Unleash
         {
             if (EventConfig?.ImpressionEvent == null)
             {
-                Logger.Error($"UNLEASH: Unleash->ImpressionData callback is null, unable to emit event");
+                Logger.Error(() => $"UNLEASH: Unleash->ImpressionData callback is null, unable to emit event");
                 return;
             }
 
@@ -392,7 +392,7 @@ namespace Unleash
             }
             catch (Exception ex)
             {
-                Logger.Error($"UNLEASH: Emitting impression event callback threw exception: {ex.Message}");
+                Logger.Error(() => $"UNLEASH: Emitting impression event callback threw exception: {ex.Message}");
             }
         }
 

--- a/src/Unleash/Internal/CachedFilesLoader.cs
+++ b/src/Unleash/Internal/CachedFilesLoader.cs
@@ -49,7 +49,7 @@ namespace Unleash.Internal
                 }
                 catch (IOException ex)
                 {
-                    Logger.ErrorException($"UNLEASH: Unhandled exception when writing to ETag file '{etagFile}'.", ex);
+                    Logger.Error(() => $"UNLEASH: Unhandled exception when writing to ETag file '{etagFile}'.", ex);
                     eventConfig?.RaiseError(new ErrorEvent() { Error = ex, ErrorType = ErrorType.FileCache });
                 }
             }
@@ -61,7 +61,7 @@ namespace Unleash.Internal
                 }
                 catch (IOException ex)
                 {
-                    Logger.ErrorException($"UNLEASH: Unhandled exception when reading from ETag file '{etagFile}'.", ex);
+                    Logger.Error(() => $"UNLEASH: Unhandled exception when reading from ETag file '{etagFile}'.", ex);
                     eventConfig?.RaiseError(new ErrorEvent() { Error = ex, ErrorType = ErrorType.FileCache });
                 }
             }
@@ -76,7 +76,7 @@ namespace Unleash.Internal
                 }
                 catch (IOException ex)
                 {
-                    Logger.ErrorException($"UNLEASH: Unhandled exception when writing to toggle file '{toggleFile}'.", ex);
+                    Logger.Error(() => $"UNLEASH: Unhandled exception when writing to toggle file '{toggleFile}'.", ex);
                     eventConfig?.RaiseError(new ErrorEvent() { Error = ex, ErrorType = ErrorType.FileCache });
                 }
             }
@@ -91,7 +91,7 @@ namespace Unleash.Internal
                 }
                 catch (IOException ex)
                 {
-                    Logger.ErrorException($"UNLEASH: Unhandled exception when reading from toggle file '{toggleFile}'.", ex);
+                    Logger.Error(() => $"UNLEASH: Unhandled exception when reading from toggle file '{toggleFile}'.", ex);
                     eventConfig?.RaiseError(new ErrorEvent() { Error = ex, ErrorType = ErrorType.FileCache });
                 }
             }

--- a/src/Unleash/Internal/UnleashExtensions.cs
+++ b/src/Unleash/Internal/UnleashExtensions.cs
@@ -48,7 +48,7 @@ namespace Unleash.Internal
             {
                 // race condition with Dispose can cause trigger to be called when underlying
                 // timer is being disposed - and a change will fail in this case.
-                // see 
+                // see
                 // https://msdn.microsoft.com/en-us/library/b97tkt95(v=vs.110).aspx#Anchor_2
                 if (disposeEnded)
                 {
@@ -98,7 +98,7 @@ namespace Unleash.Internal
             }
             catch (Exception exception)
             {
-                Logger.Trace("UNLEASH: Failed to extract local ip address", exception);
+                Logger.Trace(() => "UNLEASH: Failed to extract local ip address", exception);
                 return "undefined";
             }
         }

--- a/src/Unleash/LibLog.cs
+++ b/src/Unleash/LibLog.cs
@@ -33,7 +33,7 @@
 // this can have unintended consequences of consumers of your library using your library to resolve a logger. If the
 // reason is because you want to open this functionality to other projects within your solution,
 // consider [InternalsVisibleTo] instead.
-// 
+//
 // Define LIBLOG_PROVIDERS_ONLY if your library provides its own logging API and you just want to use the
 // LibLog providers internally to provide built in support for popular logging frameworks.
 
@@ -98,7 +98,7 @@ namespace Unleash.Logging
         /// <remarks>
         /// Note to implementers: the message func should not be called if the loglevel is not enabled
         /// so as not to incur performance penalties.
-        /// 
+        ///
         /// To check IsEnabled call Log with only LogLevel and check the return value, no event will be written.
         /// </remarks>
         bool Log(LogLevel logLevel, Func<string> messageFunc, Exception exception = null, params object[] formatParameters);
@@ -172,8 +172,10 @@ namespace Unleash.Logging
 
         public static void Debug(this ILog logger, Func<string> messageFunc)
         {
-            GuardAgainstNullLogger(logger);
-            logger.Log(LogLevel.Debug, WrapLogInternal(messageFunc));
+            if (logger.IsDebugEnabled())
+            {
+                logger.Log(LogLevel.Debug, WrapLogInternal(messageFunc));
+            }
         }
 
         public static void Debug(this ILog logger, string message)
@@ -220,8 +222,10 @@ namespace Unleash.Logging
 
         public static void Error(this ILog logger, Func<string> messageFunc)
         {
-            GuardAgainstNullLogger(logger);
-            logger.Log(LogLevel.Error, WrapLogInternal(messageFunc));
+            if (logger.IsErrorEnabled())
+            {
+                 logger.Log(LogLevel.Error, WrapLogInternal(messageFunc));
+            }
         }
 
         public static void Error(this ILog logger, string message)
@@ -260,7 +264,10 @@ namespace Unleash.Logging
 
         public static void Fatal(this ILog logger, Func<string> messageFunc)
         {
-            logger.Log(LogLevel.Fatal, WrapLogInternal(messageFunc));
+            if (logger.IsFatalEnabled())
+            {
+                logger.Log(LogLevel.Fatal, WrapLogInternal(messageFunc));
+            }
         }
 
         public static void Fatal(this ILog logger, string message)
@@ -299,8 +306,10 @@ namespace Unleash.Logging
 
         public static void Info(this ILog logger, Func<string> messageFunc)
         {
-            GuardAgainstNullLogger(logger);
-            logger.Log(LogLevel.Info, WrapLogInternal(messageFunc));
+            if (logger.IsInfoEnabled())
+            {
+                logger.Log(LogLevel.Info, WrapLogInternal(messageFunc));
+            }
         }
 
         public static void Info(this ILog logger, string message)
@@ -339,8 +348,10 @@ namespace Unleash.Logging
 
         public static void Trace(this ILog logger, Func<string> messageFunc)
         {
-            GuardAgainstNullLogger(logger);
-            logger.Log(LogLevel.Trace, WrapLogInternal(messageFunc));
+            if (logger.IsTraceEnabled())
+            {
+                logger.Log(LogLevel.Trace, WrapLogInternal(messageFunc));
+            }
         }
 
         public static void Trace(this ILog logger, string message)
@@ -379,8 +390,10 @@ namespace Unleash.Logging
 
         public static void Warn(this ILog logger, Func<string> messageFunc)
         {
-            GuardAgainstNullLogger(logger);
-            logger.Log(LogLevel.Warn, WrapLogInternal(messageFunc));
+            if (logger.IsWarnEnabled())
+            {
+                logger.Log(LogLevel.Warn, WrapLogInternal(messageFunc));
+            }
         }
 
         public static void Warn(this ILog logger, string message)
@@ -551,10 +564,10 @@ namespace Unleash.Logging
         public static bool IsDisabled { get; set; }
 
         /// <summary>
-        /// Sets an action that is invoked when a consumer of your library has called SetCurrentLogProvider. It is 
+        /// Sets an action that is invoked when a consumer of your library has called SetCurrentLogProvider. It is
         /// important that hook into this if you are using child libraries (especially ilmerged ones) that are using
         /// LibLog (or other logging abstraction) so you adapt and delegate to them.
-        /// <see cref="SetCurrentLogProvider"/> 
+        /// <see cref="SetCurrentLogProvider"/>
         /// </summary>
         internal static Action<ILogProvider> OnCurrentLogProviderSet
         {
@@ -2264,9 +2277,9 @@ namespace Unleash.Logging.LogProviders
 
         /// <summary>
         /// Some logging frameworks support structured logging, such as serilog. This will allow you to add names to structured data in a format string:
-        /// For example: Log("Log message to {user}", user). This only works with serilog, but as the user of LibLog, you don't know if serilog is actually 
-        /// used. So, this class simulates that. it will replace any text in {curly braces} with an index number. 
-        /// 
+        /// For example: Log("Log message to {user}", user). This only works with serilog, but as the user of LibLog, you don't know if serilog is actually
+        /// used. So, this class simulates that. it will replace any text in {curly braces} with an index number.
+        ///
         /// "Log {message} to {user}" would turn into => "Log {0} to {1}". Then the format parameters are handled using regular .net string.Format.
         /// </summary>
         /// <param name="messageBuilder">The message builder.</param>

--- a/src/Unleash/LibLog.cs
+++ b/src/Unleash/LibLog.cs
@@ -174,7 +174,7 @@ namespace Unleash.Logging
         {
             if (logger.IsDebugEnabled())
             {
-                logger.Log(LogLevel.Debug, WrapLogInternal(messageFunc));
+                logger.Log(LogLevel.Debug, messageFunc);
             }
         }
 
@@ -224,7 +224,7 @@ namespace Unleash.Logging
         {
             if (logger.IsErrorEnabled())
             {
-                 logger.Log(LogLevel.Error, WrapLogInternal(messageFunc));
+                 logger.Log(LogLevel.Error, messageFunc);
             }
         }
 
@@ -266,7 +266,7 @@ namespace Unleash.Logging
         {
             if (logger.IsFatalEnabled())
             {
-                logger.Log(LogLevel.Fatal, WrapLogInternal(messageFunc));
+                logger.Log(LogLevel.Fatal, messageFunc);
             }
         }
 
@@ -308,7 +308,7 @@ namespace Unleash.Logging
         {
             if (logger.IsInfoEnabled())
             {
-                logger.Log(LogLevel.Info, WrapLogInternal(messageFunc));
+                logger.Log(LogLevel.Info, messageFunc);
             }
         }
 
@@ -350,7 +350,7 @@ namespace Unleash.Logging
         {
             if (logger.IsTraceEnabled())
             {
-                logger.Log(LogLevel.Trace, WrapLogInternal(messageFunc));
+                logger.Log(LogLevel.Trace, messageFunc);
             }
         }
 
@@ -392,7 +392,7 @@ namespace Unleash.Logging
         {
             if (logger.IsWarnEnabled())
             {
-                logger.Log(LogLevel.Warn, WrapLogInternal(messageFunc));
+                logger.Log(LogLevel.Warn, messageFunc);
             }
         }
 
@@ -445,42 +445,14 @@ namespace Unleash.Logging
         }
 
         // Avoid the closure allocation, see https://gist.github.com/AArnott/d285feef75c18f6ecd2b
-        private static Func<T> AsFunc<T>(this T value) where T : class
+        private static Func<string> AsFunc(this string value)
         {
             return value.Return;
         }
 
-        private static T Return<T>(this T value)
+        private static string Return(this string value)
         {
             return value;
-        }
-
-        // Allow passing callsite-logger-type to LogProviderBase using messageFunc
-        internal static Func<string> WrapLogSafeInternal(LoggerExecutionWrapper logger, Func<string> messageFunc)
-        {
-            Func<string> wrappedMessageFunc = () =>
-            {
-                try
-                {
-                    return messageFunc();
-                }
-                catch (Exception ex)
-                {
-                    logger.WrappedLogger(LogLevel.Error, () => LoggerExecutionWrapper.FailedToGenerateLogMessage, ex);
-                }
-                return null;
-            };
-            return wrappedMessageFunc;
-        }
-
-        // Allow passing callsite-logger-type to LogProviderBase using messageFunc
-        private static Func<string> WrapLogInternal(Func<string> messageFunc)
-        {
-            Func<string> wrappedMessageFunc = () =>
-            {
-                return messageFunc();
-            };
-            return wrappedMessageFunc;
         }
     }
 #endif

--- a/src/Unleash/LibLog.cs
+++ b/src/Unleash/LibLog.cs
@@ -134,6 +134,140 @@ namespace Unleash.Logging
 #endif
     static partial class LogExtensions
     {
+#if LIBLOG_PUBLIC
+        public static bool IsDebugEnabled(this ILog logger)
+        {
+            GuardAgainstNullLogger(logger);
+            return logger.Log(LogLevel.Debug, null);
+        }
+
+        public static bool IsErrorEnabled(this ILog logger)
+        {
+            GuardAgainstNullLogger(logger);
+            return logger.Log(LogLevel.Error, null);
+        }
+
+        public static bool IsFatalEnabled(this ILog logger)
+        {
+            GuardAgainstNullLogger(logger);
+            return logger.Log(LogLevel.Fatal, null);
+        }
+
+        public static bool IsInfoEnabled(this ILog logger)
+        {
+            GuardAgainstNullLogger(logger);
+            return logger.Log(LogLevel.Info, null);
+        }
+
+        public static bool IsTraceEnabled(this ILog logger)
+        {
+            GuardAgainstNullLogger(logger);
+            return logger.Log(LogLevel.Trace, null);
+        }
+
+        public static bool IsWarnEnabled(this ILog logger)
+        {
+            GuardAgainstNullLogger(logger);
+            return logger.Log(LogLevel.Warn, null);
+        }
+
+        public static void Debug(this ILog logger, string message) => logger.Debug(message.AsFunc());
+
+        public static void Debug(this ILog logger, string message, params object[] args)
+            => logger.Debug(message.AsFunc(), null, args);
+
+        public static void Debug(this ILog logger, Exception exception, string message, params object[] args)
+            => logger.Debug(message.AsFunc(), exception, args);
+
+        public static void DebugFormat(this ILog logger, string message, params object[] args)
+            => logger.Debug(message.AsFunc(), null, args);
+
+        public static void DebugException(this ILog logger, string message, Exception exception)
+            => logger.Debug(message.AsFunc(), exception);
+
+        public static void DebugException(this ILog logger, string message, Exception exception, params object[] formatParams)
+            => logger.Debug(message.AsFunc(), exception, formatParams);
+
+        public static void Error(this ILog logger, string message)
+            => logger.Error(message.AsFunc());
+
+        public static void Error(this ILog logger, string message, params object[] args)
+            => logger.Error(message.AsFunc(), null, args);
+
+        public static void Error(this ILog logger, Exception exception, string message, params object[] args)
+            => logger.Error(message.AsFunc(), exception, args);
+
+        public static void ErrorFormat(this ILog logger, string message, params object[] args)
+            => logger.Error(message.AsFunc(), null, args);
+
+        public static void ErrorException(this ILog logger, string message, Exception exception, params object[] formatParams)
+            => logger.Error(message.AsFunc(), exception, formatParams);
+
+        public static void Fatal(this ILog logger, string message)
+            => logger.Fatal(message.AsFunc());
+
+        public static void Fatal(this ILog logger, string message, params object[] args)
+            => logger.Fatal(message.AsFunc(), null, args);
+
+        public static void Fatal(this ILog logger, Exception exception, string message, params object[] args)
+            => logger.Fatal(message.AsFunc(), exception, args);
+
+        public static void FatalFormat(this ILog logger, string message, params object[] args)
+            => logger.Fatal(message.AsFunc(), null, args);
+
+        public static void FatalException(this ILog logger, string message, Exception exception, params object[] formatParams)
+            => logger.Fatal(message.AsFunc(), exception, formatParams);
+
+        public static void Info(this ILog logger, string message)
+            => logger.Info(message.AsFunc());
+
+        public static void Info(this ILog logger, string message, params object[] args)
+            => logger.Info(message.AsFunc(), null, args);
+
+        public static void Info(this ILog logger, Exception exception, string message, params object[] args)
+            => logger.Info(message.AsFunc(), exception, args);
+
+        public static void InfoFormat(this ILog logger, string message, params object[] args)
+            => logger.Info(message.AsFunc(), null, args);
+
+        public static void InfoException(this ILog logger, string message, Exception exception, params object[] formatParams)
+            => logger.Info(message.AsFunc(), exception, formatParams);
+
+        public static void Trace(this ILog logger, string message)
+            => logger.Trace(message.AsFunc());
+
+        public static void Trace(this ILog logger, string message, params object[] args)
+            => logger.Trace(message.AsFunc(), null, args);
+
+        public static void Trace(this ILog logger, Exception exception, string message, params object[] args)
+            => logger.Trace(message.AsFunc(), exception, args);
+
+        public static void TraceFormat(this ILog logger, string message, params object[] args)
+            => logger.Trace(message.AsFunc(), null, args);
+
+        public static void TraceException(this ILog logger, string message, Exception exception, params object[] formatParams)
+            => logger.Trace(message.AsFunc(), exception, formatParams);
+
+        public static void Warn(this ILog logger, string message)
+            => logger.Warn(message.AsFunc());
+
+        public static void Warn(this ILog logger, string message, params object[] args)
+            => logger.Warn(message.AsFunc(), null, args);
+
+        public static void Warn(this ILog logger, Exception exception, string message, params object[] args)
+            => logger.Warn(message.AsFunc(), exception, args);
+
+        public static void WarnFormat(this ILog logger, string message, params object[] args)
+            => logger.Warn(message.AsFunc(), null, args);
+
+        public static void WarnException(this ILog logger, string message, Exception exception, params object[] formatParams)
+            => logger.Warn(message.AsFunc(), exception, formatParams);
+
+        // Avoid the closure allocation, see https://gist.github.com/AArnott/d285feef75c18f6ecd2b
+        private static Func<T> AsFunc<T>(this T value) where T : class => value.Return;
+
+        private static T Return<T>(this T value) => value;
+#endif
         public static void Debug(this ILog logger, Func<string> messageFunc, Exception exception = null, params object[] args)
             => Log(logger, LogLevel.Debug, messageFunc, exception, args);
 
@@ -154,15 +288,20 @@ namespace Unleash.Logging
 
         private static void Log(ILog logger, LogLevel logLevel, Func<string> messageFunc, Exception exception, params object[] args)
         {
-            if (logger == null)
-            {
-                throw new ArgumentNullException("logger");
-            }
+            GuardAgainstNullLogger(logger);
 
             // Make sure logging is on for the provided level.
             if (logger.Log(logLevel, null))
             {
                 logger.Log(logLevel, messageFunc, exception, args);
+            }
+        }
+
+        private static void GuardAgainstNullLogger(ILog logger)
+        {
+            if (logger == null)
+            {
+                throw new ArgumentNullException("logger");
             }
         }
 

--- a/src/Unleash/LibLog.cs
+++ b/src/Unleash/LibLog.cs
@@ -134,326 +134,57 @@ namespace Unleash.Logging
 #endif
     static partial class LogExtensions
     {
-        public static bool IsDebugEnabled(this ILog logger)
-        {
-            GuardAgainstNullLogger(logger);
-            return logger.Log(LogLevel.Debug, null);
-        }
+        public static void Debug(this ILog logger, Func<string> messageFunc, Exception exception = null, params object[] args)
+            => Log(logger, LogLevel.Debug, messageFunc, exception, args);
 
-        public static bool IsErrorEnabled(this ILog logger)
-        {
-            GuardAgainstNullLogger(logger);
-            return logger.Log(LogLevel.Error, null);
-        }
+        public static void Error(this ILog logger, Func<string> messageFunc, Exception exception = null, params object[] args)
+            => Log(logger, LogLevel.Error, messageFunc, exception, args);
 
-        public static bool IsFatalEnabled(this ILog logger)
-        {
-            GuardAgainstNullLogger(logger);
-            return logger.Log(LogLevel.Fatal, null);
-        }
+        public static void Fatal(this ILog logger, Func<string> messageFunc, Exception exception = null, params object[] args)
+            => Log(logger, LogLevel.Fatal, messageFunc, exception, args);
 
-        public static bool IsInfoEnabled(this ILog logger)
-        {
-            GuardAgainstNullLogger(logger);
-            return logger.Log(LogLevel.Info, null);
-        }
+        public static void Info(this ILog logger, Func<string> messageFunc, Exception exception = null, params object[] args)
+            => Log(logger, LogLevel.Info, messageFunc, exception, args);
 
-        public static bool IsTraceEnabled(this ILog logger)
-        {
-            GuardAgainstNullLogger(logger);
-            return logger.Log(LogLevel.Trace, null);
-        }
+        public static void Trace(this ILog logger, Func<string> messageFunc, Exception exception = null, params object[] args)
+            => Log(logger, LogLevel.Trace, messageFunc, exception, null, args);
 
-        public static bool IsWarnEnabled(this ILog logger)
-        {
-            GuardAgainstNullLogger(logger);
-            return logger.Log(LogLevel.Warn, null);
-        }
+        public static void Warn(this ILog logger, Func<string> messageFunc, Exception exception = null, params object[] args)
+            => Log(logger, LogLevel.Warn, messageFunc, exception, args);
 
-        public static void Debug(this ILog logger, Func<string> messageFunc)
-        {
-            if (logger.IsDebugEnabled())
-            {
-                logger.Log(LogLevel.Debug, messageFunc);
-            }
-        }
-
-        public static void Debug(this ILog logger, string message)
-        {
-            if (logger.IsDebugEnabled())
-            {
-                logger.Log(LogLevel.Debug, message.AsFunc());
-            }
-        }
-
-        public static void Debug(this ILog logger, string message, params object[] args)
-        {
-            logger.DebugFormat(message, args);
-        }
-
-        public static void Debug(this ILog logger, Exception exception, string message, params object[] args)
-        {
-            logger.DebugException(message, exception, args);
-        }
-
-        public static void DebugFormat(this ILog logger, string message, params object[] args)
-        {
-            if (logger.IsDebugEnabled())
-            {
-                logger.LogFormat(LogLevel.Debug, message, args);
-            }
-        }
-
-        public static void DebugException(this ILog logger, string message, Exception exception)
-        {
-            if (logger.IsDebugEnabled())
-            {
-                logger.Log(LogLevel.Debug, message.AsFunc(), exception);
-            }
-        }
-
-        public static void DebugException(this ILog logger, string message, Exception exception, params object[] formatParams)
-        {
-            if (logger.IsDebugEnabled())
-            {
-                logger.Log(LogLevel.Debug, message.AsFunc(), exception, formatParams);
-            }
-        }
-
-        public static void Error(this ILog logger, Func<string> messageFunc)
-        {
-            if (logger.IsErrorEnabled())
-            {
-                 logger.Log(LogLevel.Error, messageFunc);
-            }
-        }
-
-        public static void Error(this ILog logger, string message)
-        {
-            if (logger.IsErrorEnabled())
-            {
-                logger.Log(LogLevel.Error, message.AsFunc());
-            }
-        }
-
-        public static void Error(this ILog logger, string message, params object[] args)
-        {
-            logger.ErrorFormat(message, args);
-        }
-
-        public static void Error(this ILog logger, Exception exception, string message, params object[] args)
-        {
-            logger.ErrorException(message, exception, args);
-        }
-
-        public static void ErrorFormat(this ILog logger, string message, params object[] args)
-        {
-            if (logger.IsErrorEnabled())
-            {
-                logger.LogFormat(LogLevel.Error, message, args);
-            }
-        }
-
-        public static void ErrorException(this ILog logger, string message, Exception exception, params object[] formatParams)
-        {
-            if (logger.IsErrorEnabled())
-            {
-                logger.Log(LogLevel.Error, message.AsFunc(), exception, formatParams);
-            }
-        }
-
-        public static void Fatal(this ILog logger, Func<string> messageFunc)
-        {
-            if (logger.IsFatalEnabled())
-            {
-                logger.Log(LogLevel.Fatal, messageFunc);
-            }
-        }
-
-        public static void Fatal(this ILog logger, string message)
-        {
-            if (logger.IsFatalEnabled())
-            {
-                logger.Log(LogLevel.Fatal, message.AsFunc());
-            }
-        }
-
-        public static void Fatal(this ILog logger, string message, params object[] args)
-        {
-            logger.FatalFormat(message, args);
-        }
-
-        public static void Fatal(this ILog logger, Exception exception, string message, params object[] args)
-        {
-            logger.FatalException(message, exception, args);
-        }
-
-        public static void FatalFormat(this ILog logger, string message, params object[] args)
-        {
-            if (logger.IsFatalEnabled())
-            {
-                logger.LogFormat(LogLevel.Fatal, message, args);
-            }
-        }
-
-        public static void FatalException(this ILog logger, string message, Exception exception, params object[] formatParams)
-        {
-            if (logger.IsFatalEnabled())
-            {
-                logger.Log(LogLevel.Fatal, message.AsFunc(), exception, formatParams);
-            }
-        }
-
-        public static void Info(this ILog logger, Func<string> messageFunc)
-        {
-            if (logger.IsInfoEnabled())
-            {
-                logger.Log(LogLevel.Info, messageFunc);
-            }
-        }
-
-        public static void Info(this ILog logger, string message)
-        {
-            if (logger.IsInfoEnabled())
-            {
-                logger.Log(LogLevel.Info, message.AsFunc());
-            }
-        }
-
-        public static void Info(this ILog logger, string message, params object[] args)
-        {
-            logger.InfoFormat(message, args);
-        }
-
-        public static void Info(this ILog logger, Exception exception, string message, params object[] args)
-        {
-            logger.InfoException(message, exception, args);
-        }
-
-        public static void InfoFormat(this ILog logger, string message, params object[] args)
-        {
-            if (logger.IsInfoEnabled())
-            {
-                logger.LogFormat(LogLevel.Info, message, args);
-            }
-        }
-
-        public static void InfoException(this ILog logger, string message, Exception exception, params object[] formatParams)
-        {
-            if (logger.IsInfoEnabled())
-            {
-                logger.Log(LogLevel.Info, message.AsFunc(), exception, formatParams);
-            }
-        }
-
-        public static void Trace(this ILog logger, Func<string> messageFunc)
-        {
-            if (logger.IsTraceEnabled())
-            {
-                logger.Log(LogLevel.Trace, messageFunc);
-            }
-        }
-
-        public static void Trace(this ILog logger, string message)
-        {
-            if (logger.IsTraceEnabled())
-            {
-                logger.Log(LogLevel.Trace, message.AsFunc());
-            }
-        }
-
-        public static void Trace(this ILog logger, string message, params object[] args)
-        {
-            logger.TraceFormat(message, args);
-        }
-
-        public static void Trace(this ILog logger, Exception exception, string message, params object[] args)
-        {
-            logger.TraceException(message, exception, args);
-        }
-
-        public static void TraceFormat(this ILog logger, string message, params object[] args)
-        {
-            if (logger.IsTraceEnabled())
-            {
-                logger.LogFormat(LogLevel.Trace, message, args);
-            }
-        }
-
-        public static void TraceException(this ILog logger, string message, Exception exception, params object[] formatParams)
-        {
-            if (logger.IsTraceEnabled())
-            {
-                logger.Log(LogLevel.Trace, message.AsFunc(), exception, formatParams);
-            }
-        }
-
-        public static void Warn(this ILog logger, Func<string> messageFunc)
-        {
-            if (logger.IsWarnEnabled())
-            {
-                logger.Log(LogLevel.Warn, messageFunc);
-            }
-        }
-
-        public static void Warn(this ILog logger, string message)
-        {
-            if (logger.IsWarnEnabled())
-            {
-                logger.Log(LogLevel.Warn, message.AsFunc());
-            }
-        }
-
-        public static void Warn(this ILog logger, string message, params object[] args)
-        {
-            logger.WarnFormat(message, args);
-        }
-
-        public static void Warn(this ILog logger, Exception exception, string message, params object[] args)
-        {
-            logger.WarnException(message, exception, args);
-        }
-
-        public static void WarnFormat(this ILog logger, string message, params object[] args)
-        {
-            if (logger.IsWarnEnabled())
-            {
-                logger.LogFormat(LogLevel.Warn, message, args);
-            }
-        }
-
-        public static void WarnException(this ILog logger, string message, Exception exception, params object[] formatParams)
-        {
-            if (logger.IsWarnEnabled())
-            {
-                logger.Log(LogLevel.Warn, message.AsFunc(), exception, formatParams);
-            }
-        }
-
-        // ReSharper disable once UnusedParameter.Local
-        private static void GuardAgainstNullLogger(ILog logger)
+        private static void Log(ILog logger, LogLevel logLevel, Func<string> messageFunc, Exception exception, params object[] args)
         {
             if (logger == null)
             {
                 throw new ArgumentNullException("logger");
             }
+
+            // Make sure logging is on for the provided level.
+            if (logger.Log(logLevel, null))
+            {
+                logger.Log(logLevel, messageFunc, exception, args);
+            }
         }
 
-        private static void LogFormat(this ILog logger, LogLevel logLevel, string message, params object[] args)
+#if !LIBLOG_PORTABLE
+        // Allow passing callsite-logger-type to LogProviderBase using messageFunc
+        internal static Func<string> WrapLogSafeInternal(LoggerExecutionWrapper logger, Func<string> messageFunc)
         {
-            logger.Log(logLevel, message.AsFunc(), null, args);
+            Func<string> wrappedMessageFunc = () =>
+            {
+                try
+                {
+                    return messageFunc();
+                }
+                catch (Exception ex)
+                {
+                    logger.WrappedLogger(LogLevel.Error, () => LoggerExecutionWrapper.FailedToGenerateLogMessage, ex);
+                }
+                return null;
+            };
+            return wrappedMessageFunc;
         }
-
-        // Avoid the closure allocation, see https://gist.github.com/AArnott/d285feef75c18f6ecd2b
-        private static Func<string> AsFunc(this string value)
-        {
-            return value.Return;
-        }
-
-        private static string Return(this string value)
-        {
-            return value;
-        }
+#endif
     }
 #endif
 

--- a/src/Unleash/Scheduling/FetchFeatureTogglesTask.cs
+++ b/src/Unleash/Scheduling/FetchFeatureTogglesTask.cs
@@ -53,7 +53,7 @@ namespace Unleash.Scheduling
             }
             catch (HttpRequestException ex)
             {
-                Logger.ErrorException($"UNLEASH: Unhandled exception when fetching toggles.", ex);
+                Logger.Error(() => $"UNLEASH: Unhandled exception when fetching toggles.", ex);
                 eventConfig?.RaiseError(new ErrorEvent() { ErrorType = ErrorType.Client, Error = ex });
                 throw new UnleashException("Exception while fetching from API", ex);
             }
@@ -80,10 +80,10 @@ namespace Unleash.Scheduling
                 {
                     jsonSerializer.Serialize(fs, result.ToggleCollection);
                 }
-            } 
+            }
             catch (IOException ex)
             {
-                Logger.WarnException($"UNLEASH: Exception when writing to toggle file '{toggleFile}'.", ex);
+                Logger.Warn(() => $"UNLEASH: Exception when writing to toggle file '{toggleFile}'.", ex);
                 eventConfig?.RaiseError(new ErrorEvent() { ErrorType = ErrorType.TogglesBackup, Error = ex });
             }
 
@@ -95,7 +95,7 @@ namespace Unleash.Scheduling
             }
             catch (IOException ex)
             {
-                Logger.WarnException($"UNLEASH: Exception when writing to ETag file '{etagFile}'.", ex);
+                Logger.Warn(() => $"UNLEASH: Exception when writing to ETag file '{etagFile}'.", ex);
                 eventConfig?.RaiseError(new ErrorEvent() { ErrorType = ErrorType.TogglesBackup, Error = ex });
             }
         }

--- a/src/Unleash/Scheduling/SystemTimerScheduledTaskManager.cs
+++ b/src/Unleash/Scheduling/SystemTimerScheduledTaskManager.cs
@@ -42,12 +42,12 @@ namespace Unleash.Scheduling
                 {
                     if (!cancellationToken.IsCancellationRequested)
                     {
-                        Logger.WarnException($"UNLEASH: Task '{name}' cancelled ...", taskCanceledException);
+                        Logger.Warn(() => $"UNLEASH: Task '{name}' cancelled ...", taskCanceledException);
                     }
                 }
                 catch (Exception ex)
                 {
-                    Logger.ErrorException($"UNLEASH: Unhandled exception from background task '{name}'.", ex);
+                    Logger.Error(() => $"UNLEASH: Unhandled exception from background task '{name}'.", ex);
                 }
                 finally
                 {

--- a/src/Unleash/Strategies/Constraints/SemverConstraintOperator.cs
+++ b/src/Unleash/Strategies/Constraints/SemverConstraintOperator.cs
@@ -18,7 +18,7 @@ namespace Unleash.Strategies.Constraints
             SemanticVersion contextSemver;
             if (!SemanticVersion.TryParse(contextValue, out contextSemver))
             {
-                Logger.Info("Couldn't parse version {0} from context");
+                Logger.Info(() => "Couldn't parse version {0} from context");
                 return false;
             }
 
@@ -27,7 +27,7 @@ namespace Unleash.Strategies.Constraints
                 SemanticVersion constraintSemver;
                 if (!SemanticVersion.TryParse(constraint.Value, out constraintSemver))
                     return false;
-                
+
                 if (constraint.Inverted)
                     return !Eval(constraint.Operator, contextSemver, constraintSemver);
 

--- a/src/Unleash/Strategies/RemoteAddressStrategy.cs
+++ b/src/Unleash/Strategies/RemoteAddressStrategy.cs
@@ -35,7 +35,7 @@ namespace Unleash.Strategies
 
                 var addressRanges = ToAddressRanges(addresses);
 
-                if (!addressRanges.Any()) 
+                if (!addressRanges.Any())
                     return false;
 
                 return addressRanges
@@ -56,7 +56,7 @@ namespace Unleash.Strategies
                 }
                 catch (Exception ex)
                 {
-                    Logger.Error($"UNLEASH: RemoteAddressStrategy->ToAddressRanges threw exception: {ex.Message}. (Badly formatted IP/CIDR?)");
+                    Logger.Error(() => $"UNLEASH: RemoteAddressStrategy->ToAddressRanges threw exception: {ex.Message}. (Badly formatted IP/CIDR?)");
                 }
             }
 

--- a/src/Unleash/Utilities/ToggleBootstrapUrlProvider.cs
+++ b/src/Unleash/Utilities/ToggleBootstrapUrlProvider.cs
@@ -53,7 +53,7 @@ namespace Unleash.Utilities
                     if (!response.IsSuccessStatusCode)
                     {
                         var error = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
-                        Logger.Trace($"UNLEASH: Error {response.StatusCode} from server in 'ToggleBootstrapUrlProvider.{nameof(FetchFile)}': " + error);
+                        Logger.Trace(() => $"UNLEASH: Error {response.StatusCode} from server in 'ToggleBootstrapUrlProvider.{nameof(FetchFile)}': " + error);
 
                         if (throwOnFail)
                             throw new FetchingToggleBootstrapUrlFailedException("Failed to fetch feature toggles", response.StatusCode);
@@ -68,7 +68,7 @@ namespace Unleash.Utilities
                     }
                     catch (Exception ex)
                     {
-                        Logger.Trace($"UNLEASH: Exception in 'ToggleBootstrapUrlProvider.{nameof(FetchFile)}' during reading and deserializing ToggleCollection from stream: " + ex.Message);
+                        Logger.Trace(() => $"UNLEASH: Exception in 'ToggleBootstrapUrlProvider.{nameof(FetchFile)}' during reading and deserializing ToggleCollection from stream: " + ex.Message);
 
                         if (throwOnFail)
                             throw new UnleashException("Exception during reading and deserializing ToggleCollection from stream", ex);

--- a/src/Unleash/Utilities/WarnOnce.cs
+++ b/src/Unleash/Utilities/WarnOnce.cs
@@ -20,9 +20,9 @@ namespace Unleash.Utilities
             {
                 return;
             }
-            
+
             seen.Add(key);
-            logger.Warn(message);
+            logger.Warn(() => message);
         }
     }
 }


### PR DESCRIPTION
# Description

A high number of string allocations were found to come from `DefaultUnleash.DetermineIsEnabledAndStrategy`:
![image](https://github.com/Unleash/unleash-client-dotnet/assets/132582942/aababba4-9630-4ef7-99e7-b5564ffda3ae)

I believe this is due to the logging that's done if the toggle isn't available:
![image](https://github.com/Unleash/unleash-client-dotnet/assets/132582942/82b07f9b-3f6e-4114-a7ab-cebf7ca24552)

This will always allocate a string even if logging is disabled (or log level Warning is disabled). We should instead be passing a `Func<string>` which is a smaller allocation that will only get evaluated if logging is on.

Also, in looking at this I noticed there was inconsistant checking if a log level was enabled in `LogExtensions` so I will clean that up as well.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Using the following benchmark (note IsEnabled2 has my changes):
```
[MemoryDiagnoser]
public class Benchmark
{
    readonly UnleashContext context = new();
    readonly DefaultUnleash client = new(new UnleashSettings());

    public Benchmark()
    {
    }

    [Benchmark(Baseline = true)]
    public bool Current() => client.IsEnabled("Moo", context);

    [Benchmark]
    public bool New() => client.IsEnabled2("Moo", context);
}
```

The following results were obtained:
| Method     | Mean     | Error   | StdDev  | Ratio | Gen0   | Allocated | Alloc Ratio |
|----------- |---------:|--------:|--------:|------:|-------:|----------:|------------:|
| Current    | 179.3 ns | 1.80 ns | 1.69 ns |  1.00 | 0.0408 |     512 B |        1.00 |
| New | 105.2 ns | 1.00 ns | 0.94 ns |  0.58 | 0.0254 |     320 B |        0.63 |