### PR TITLE
fix: make semver logging actually log context value that failed parsing

### DIFF
--- a/src/Unleash/Strategies/Constraints/SemverConstraintOperator.cs
+++ b/src/Unleash/Strategies/Constraints/SemverConstraintOperator.cs
@@ -18,7 +18,7 @@ namespace Unleash.Strategies.Constraints
             SemanticVersion contextSemver;
             if (!SemanticVersion.TryParse(contextValue, out contextSemver))
             {
-                Logger.Info(() => "Couldn't parse version {0} from context");
+                Logger.Info(() => $"Couldn't parse version {contextValue} from context");
                 return false;
             }
 

--- a/tests/Unleash.Tests/Strategy/Constraints/SemverConstraintOperator_Tests.cs
+++ b/tests/Unleash.Tests/Strategy/Constraints/SemverConstraintOperator_Tests.cs
@@ -251,5 +251,27 @@ namespace Unleash.Tests.Strategy.Constraints
             // Assert
             result.Should().BeFalse();
         }
+
+        [Test]
+        public void SemverConstraint_Handles_Invalid_Semver_Without_Raising_Exception()
+        {
+            // Arrange
+            var target = new SemverConstraintOperator();
+            var constraint = new Constraint(
+                "operator_semver_test",
+                Operator.SEMVER_GT,
+                false,
+                true,
+                "definitely.not.a.valid.semver"
+            );
+            var context = new UnleashContext();
+            context.Properties.Add("operator_semver_test", "also.definitely.not.a.semver");
+
+            // Act + Assert
+            Assert.DoesNotThrow(() =>
+            {
+                target.Evaluate(constraint, context);
+            });
+        }
     }
 }


### PR DESCRIPTION
This patches the logging in the semver constraint to actually take the parameter that it needs to log, rather than throwing around a format string with nothing to format into it. This would previously cause some log implementations to crash and others to log a very unhelpful error message.