### PR TITLE
fix: throw when fetch features fails

### DIFF
--- a/src/Unleash/ClientFactory/UnleashClientFactory.cs
+++ b/src/Unleash/ClientFactory/UnleashClientFactory.cs
@@ -23,6 +23,7 @@ namespace Unleash.ClientFactory
             if (synchronousInitialization)
             {
                 settings.ScheduleFeatureToggleFetchImmediatly = false;
+                settings.ThrowOnInitialFetchFail = true;
                 var unleash = new DefaultUnleash(settings, strategies);
                 TaskFactory
                     .StartNew(() => unleash.services.FetchFeatureTogglesTask.ExecuteAsync(CancellationToken.None))
@@ -46,6 +47,7 @@ namespace Unleash.ClientFactory
             if (synchronousInitialization)
             {
                 settings.ScheduleFeatureToggleFetchImmediatly = false;
+                settings.ThrowOnInitialFetchFail = true;
                 var unleash = new DefaultUnleash(settings, strategies);
                 await unleash.services.FetchFeatureTogglesTask.ExecuteAsync(CancellationToken.None).ConfigureAwait(false);
                 return unleash;

--- a/src/Unleash/Communication/IUnleashApiClient.cs
+++ b/src/Unleash/Communication/IUnleashApiClient.cs
@@ -6,7 +6,7 @@ namespace Unleash.Communication
 {
     internal interface IUnleashApiClient
     {
-        Task<FetchTogglesResult> FetchToggles(string etag, CancellationToken cancellationToken);
+        Task<FetchTogglesResult> FetchToggles(string etag, CancellationToken cancellationToken, bool throwOnFail = false);
         Task<bool> RegisterClient(ClientRegistration registration, CancellationToken cancellationToken);
         Task<bool> SendMetrics(ThreadSafeMetricsBucket metrics, CancellationToken cancellationToken);
     }

--- a/src/Unleash/Communication/UnleashApiClient.cs
+++ b/src/Unleash/Communication/UnleashApiClient.cs
@@ -58,7 +58,7 @@ namespace Unleash.Communication
             this.projectId = projectId;
         }
 
-        public async Task<FetchTogglesResult> FetchToggles(string etag, CancellationToken cancellationToken)
+        public async Task<FetchTogglesResult> FetchToggles(string etag, CancellationToken cancellationToken, bool throwOnFail = false)
         {
             if (featureRequestsToSkip > featureRequestsSkipped)
             {
@@ -71,7 +71,7 @@ namespace Unleash.Communication
             }
 
             featureRequestsSkipped = 0;
-
+                
             string resourceUri = "client/features";
             if (!string.IsNullOrWhiteSpace(this.projectId))
                 resourceUri += "?project=" + this.projectId;
@@ -87,7 +87,7 @@ namespace Unleash.Communication
                 {
                     if (!response.IsSuccessStatusCode && response.StatusCode != HttpStatusCode.NotModified)
                     {
-                        return await HandleErrorResponse(response, resourceUri);
+                        return await HandleErrorResponse(response, resourceUri, throwOnFail);
                     }
 
                     return await HandleSuccessResponse(response, etag);
@@ -95,7 +95,7 @@ namespace Unleash.Communication
             }
         }
 
-        private async Task<FetchTogglesResult> HandleErrorResponse(HttpResponseMessage response, string resourceUri)
+        private async Task<FetchTogglesResult> HandleErrorResponse(HttpResponseMessage response, string resourceUri, bool shouldThrow = false)
         {
             if (backoffResponses.Contains((int)response.StatusCode))
             {
@@ -110,6 +110,11 @@ namespace Unleash.Communication
             var error = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
             Logger.Trace(() => $"UNLEASH: Error {response.StatusCode} from server in '{nameof(FetchToggles)}': " + error);
             eventConfig?.RaiseError(new ErrorEvent() { ErrorType = ErrorType.Client, StatusCode = response.StatusCode, Resource = resourceUri });
+
+            if (shouldThrow)
+            {
+                throw new UnleashException($"Unleash: {response.StatusCode} from server in '{nameof(FetchToggles)}': " + error);
+            }
 
             return new FetchTogglesResult
             {

--- a/src/Unleash/Communication/UnleashApiClient.cs
+++ b/src/Unleash/Communication/UnleashApiClient.cs
@@ -71,7 +71,7 @@ namespace Unleash.Communication
             }
 
             featureRequestsSkipped = 0;
-                
+
             string resourceUri = "client/features";
             if (!string.IsNullOrWhiteSpace(this.projectId))
                 resourceUri += "?project=" + this.projectId;

--- a/src/Unleash/Internal/UnleashServices.cs
+++ b/src/Unleash/Internal/UnleashServices.cs
@@ -85,7 +85,8 @@ namespace Unleash
                 settings.FileSystem,
                 eventConfig,
                 backupFile, 
-                etagBackupFile)
+                etagBackupFile,
+                settings.ThrowOnInitialFetchFail)
             {
                 ExecuteDuringStartup = settings.ScheduleFeatureToggleFetchImmediatly,
                 Interval = settings.FetchTogglesInterval,

--- a/src/Unleash/UnleashSettings.cs
+++ b/src/Unleash/UnleashSettings.cs
@@ -140,6 +140,8 @@ namespace Unleash
         /// </summary>
         internal bool ScheduleFeatureToggleFetchImmediatly { get; set; } = true;
 
+        internal bool ThrowOnInitialFetchFail { get; set; }
+
         private static string GetSdkVersion()
         {
             var assemblyName = Assembly.GetExecutingAssembly().GetName();

--- a/tests/Unleash.Tests/ClientFactory/SyncStartupUnitTest.cs
+++ b/tests/Unleash.Tests/ClientFactory/SyncStartupUnitTest.cs
@@ -91,7 +91,7 @@ namespace Unleash.Tests.ClientFactory
         [Test]
         public void Synchronous_Initialization_400s_Throws()
         {
-            // Arrange
+            // Act, Assert
             Assert.Throws<UnleashException>(() =>
             {
                 var unleash = GetUnleash(new HttpResponseMessage()
@@ -108,7 +108,7 @@ namespace Unleash.Tests.ClientFactory
         [Test]
         public void Synchronous_Initialization_429_Throws()
         {
-            // Arrange
+            // Act, Assert
             Assert.Throws<UnleashException>(() =>
             {
                 var unleash = GetUnleash(new HttpResponseMessage()
@@ -125,7 +125,7 @@ namespace Unleash.Tests.ClientFactory
         [Test]
         public void Synchronous_Initialization_304_Does_Not_Throw()
         {
-            // Arrange
+            // Act, Assert
             Assert.DoesNotThrow(() =>
             {
                 var unleash = GetUnleash(new HttpResponseMessage()
@@ -143,7 +143,7 @@ namespace Unleash.Tests.ClientFactory
         [Test]
         public void Synchronous_Initialization_Ok_Does_Not_Throw()
         {
-            // Arrange
+            // Act, Assert
             Assert.DoesNotThrow(() =>
             {
                 var unleash = GetUnleash(new HttpResponseMessage()
@@ -161,7 +161,7 @@ namespace Unleash.Tests.ClientFactory
         [Test]
         public void Synchronous_Initialization_302_Throws()
         {
-            // Arrange
+            // Act, Assert
             Assert.Throws<UnleashException>(() =>
             {
                 var unleash = GetUnleash(new HttpResponseMessage()
@@ -178,7 +178,7 @@ namespace Unleash.Tests.ClientFactory
         [Test]
         public void Synchronous_Initialization_500_Throws()
         {
-            // Arrange
+            // Act, Assert
             Assert.Throws<UnleashException>(() =>
             {
                 var unleash = GetUnleash(new HttpResponseMessage()

--- a/tests/Unleash.Tests/ExampleTests.cs
+++ b/tests/Unleash.Tests/ExampleTests.cs
@@ -14,7 +14,7 @@ namespace Unleash.Tests
         public async Task Setup()
         {
             var factory = new UnleashClientFactory();
-            unleash = await factory.CreateClientAsync(new MockedUnleashSettings(), true);
+            unleash = await factory.CreateClientAsync(new MockedUnleashSettings(instanceTag: "test instance ExampleTests"), true);
         }
 
         [Test]

--- a/tests/Unleash.Tests/IOTests.cs
+++ b/tests/Unleash.Tests/IOTests.cs
@@ -24,7 +24,7 @@ namespace Unleash.Tests
         [Test]
         public async Task GracefullyFailsWhenFileLocked()
         {
-            var settings = new MockedUnleashSettings(false);
+            var settings = new MockedUnleashSettings(false, "test instance IOTests");
             
             var toggleFile = settings.GetFeatureToggleFilePath();
             var eTagFile = settings.GetFeatureToggleETagFilePath();

--- a/tests/Unleash.Tests/Internal/ErrorEvents_Tests.cs
+++ b/tests/Unleash.Tests/Internal/ErrorEvents_Tests.cs
@@ -91,14 +91,14 @@ namespace Unleash.Tests.Internal
             };
 
             var fakeApiClient = A.Fake<IUnleashApiClient>();
-            A.CallTo(() => fakeApiClient.FetchToggles(A<string>._, A<CancellationToken>._))
+            A.CallTo(() => fakeApiClient.FetchToggles(A<string>._, A<CancellationToken>._, false))
                 .ThrowsAsync(() => new HttpRequestException("The remote server refused the connection"));
 
             var collection = new ThreadSafeToggleCollection();
             var serializer = new DynamicNewtonsoftJsonSerializer();
             var filesystem = new MockFileSystem();
             var tokenSource = new CancellationTokenSource();
-            var task = new FetchFeatureTogglesTask(fakeApiClient, collection, serializer, filesystem, callbackConfig, "togglefile.txt", "etagfile.txt");
+            var task = new FetchFeatureTogglesTask(fakeApiClient, collection, serializer, filesystem, callbackConfig, "togglefile.txt", "etagfile.txt", false);
 
             // Act
             try
@@ -128,7 +128,7 @@ namespace Unleash.Tests.Internal
             };
 
             var fakeApiClient = A.Fake<IUnleashApiClient>();
-            A.CallTo(() => fakeApiClient.FetchToggles(A<string>._, A<CancellationToken>._))
+            A.CallTo(() => fakeApiClient.FetchToggles(A<string>._, A<CancellationToken>._, false))
                 .Returns(Task.FromResult(new FetchTogglesResult() { HasChanged = true, ToggleCollection = new ToggleCollection(), Etag = "one" }));
 
             var collection = new ThreadSafeToggleCollection();
@@ -138,7 +138,7 @@ namespace Unleash.Tests.Internal
 
             var filesystem = new MockFileSystem();
             var tokenSource = new CancellationTokenSource();
-            var task = new FetchFeatureTogglesTask(fakeApiClient, collection, serializer, filesystem, callbackConfig, "togglefile.txt", "etagfile.txt");
+            var task = new FetchFeatureTogglesTask(fakeApiClient, collection, serializer, filesystem, callbackConfig, "togglefile.txt", "etagfile.txt", false);
 
             // Act
             Task.WaitAll(task.ExecuteAsync(tokenSource.Token));
@@ -162,7 +162,7 @@ namespace Unleash.Tests.Internal
             };
 
             var fakeApiClient = A.Fake<IUnleashApiClient>();
-            A.CallTo(() => fakeApiClient.FetchToggles(A<string>._, A<CancellationToken>._))
+            A.CallTo(() => fakeApiClient.FetchToggles(A<string>._, A<CancellationToken>._, false))
                 .Returns(Task.FromResult(new FetchTogglesResult() { HasChanged = true, ToggleCollection = new ToggleCollection(), Etag = "one" }));
 
             var collection = new ThreadSafeToggleCollection();
@@ -173,7 +173,7 @@ namespace Unleash.Tests.Internal
                 .Throws(() => new IOException(exceptionMessage));
 
             var tokenSource = new CancellationTokenSource();
-            var task = new FetchFeatureTogglesTask(fakeApiClient, collection, serializer, filesystem, callbackConfig, "togglefile.txt", "etagfile.txt");
+            var task = new FetchFeatureTogglesTask(fakeApiClient, collection, serializer, filesystem, callbackConfig, "togglefile.txt", "etagfile.txt", false);
 
             // Act
             Task.WaitAll(task.ExecuteAsync(tokenSource.Token));

--- a/tests/Unleash.Tests/Internal/TogglesUpdatedEvent_Tests.cs
+++ b/tests/Unleash.Tests/Internal/TogglesUpdatedEvent_Tests.cs
@@ -26,7 +26,7 @@ namespace Unleash.Tests.Internal
             };
 
             var fakeApiClient = A.Fake<IUnleashApiClient>();
-            A.CallTo(() => fakeApiClient.FetchToggles(A<string>._, A<CancellationToken>._))
+            A.CallTo(() => fakeApiClient.FetchToggles(A<string>._, A<CancellationToken>._, false))
                 .Returns(Task.FromResult(new FetchTogglesResult { HasChanged = true, ToggleCollection = new ToggleCollection(), Etag = "one" }));
 
             var collection = new ThreadSafeToggleCollection();
@@ -35,7 +35,7 @@ namespace Unleash.Tests.Internal
 
             var filesystem = new MockFileSystem();
             var tokenSource = new CancellationTokenSource();
-            var task = new FetchFeatureTogglesTask(fakeApiClient, collection, serializer, filesystem, callbackConfig, "togglefile.txt", "etagfile.txt");
+            var task = new FetchFeatureTogglesTask(fakeApiClient, collection, serializer, filesystem, callbackConfig, "togglefile.txt", "etagfile.txt", false);
 
             // Act
             Task.WaitAll(task.ExecuteAsync(tokenSource.Token));
@@ -55,7 +55,7 @@ namespace Unleash.Tests.Internal
             };
 
             var fakeApiClient = A.Fake<IUnleashApiClient>();
-            A.CallTo(() => fakeApiClient.FetchToggles(A<string>._, A<CancellationToken>._))
+            A.CallTo(() => fakeApiClient.FetchToggles(A<string>._, A<CancellationToken>._, false))
                 .Returns(Task.FromResult(new FetchTogglesResult { HasChanged = false, ToggleCollection = new ToggleCollection(), Etag = "one" }));
 
             var collection = new ThreadSafeToggleCollection();
@@ -64,7 +64,7 @@ namespace Unleash.Tests.Internal
 
             var filesystem = new MockFileSystem();
             var tokenSource = new CancellationTokenSource();
-            var task = new FetchFeatureTogglesTask(fakeApiClient, collection, serializer, filesystem, callbackConfig, "togglefile.txt", "etagfile.txt");
+            var task = new FetchFeatureTogglesTask(fakeApiClient, collection, serializer, filesystem, callbackConfig, "togglefile.txt", "etagfile.txt", false);
 
             // Act
             Task.WaitAll(task.ExecuteAsync(tokenSource.Token));
@@ -92,7 +92,7 @@ namespace Unleash.Tests.Internal
             };
 
             var fakeApiClient = A.Fake<IUnleashApiClient>();
-            A.CallTo(() => fakeApiClient.FetchToggles(A<string>._, A<CancellationToken>._))
+            A.CallTo(() => fakeApiClient.FetchToggles(A<string>._, A<CancellationToken>._, false))
                 .Returns(Task.FromResult(new FetchTogglesResult { HasChanged = true, ToggleCollection = fetchResultToggleCollection, Etag = "one" }));
 
             var serializer = new DynamicNewtonsoftJsonSerializer();
@@ -100,7 +100,7 @@ namespace Unleash.Tests.Internal
 
             var filesystem = new MockFileSystem();
             var tokenSource = new CancellationTokenSource();
-            var task = new FetchFeatureTogglesTask(fakeApiClient, toggleCollection, serializer, filesystem, callbackConfig, "togglefile.txt", "etagfile.txt");
+            var task = new FetchFeatureTogglesTask(fakeApiClient, toggleCollection, serializer, filesystem, callbackConfig, "togglefile.txt", "etagfile.txt", false);
 
             // Act
             Task.WaitAll(task.ExecuteAsync(tokenSource.Token));

--- a/tests/Unleash.Tests/Mock/MockApiClient.cs
+++ b/tests/Unleash.Tests/Mock/MockApiClient.cs
@@ -33,7 +33,7 @@ namespace Unleash.Tests.Mock
             })
         });
 
-        public Task<FetchTogglesResult> FetchToggles(string etag, CancellationToken cancellationToken)
+        public Task<FetchTogglesResult> FetchToggles(string etag, CancellationToken cancellationToken, bool throwOnFail = false)
         {
             return Task.Run(async delegate
             {

--- a/tests/Unleash.Tests/MockedUnleashSettings.cs
+++ b/tests/Unleash.Tests/MockedUnleashSettings.cs
@@ -8,10 +8,10 @@ namespace Unleash.Tests
 {
     public class MockedUnleashSettings : UnleashSettings
     {
-        public MockedUnleashSettings(bool mockFileSystem = true)
+        public MockedUnleashSettings(bool mockFileSystem = true, string instanceTag = "test instance 1")
         {
             AppName = "test";
-            InstanceTag = "test instance 1";
+            InstanceTag = instanceTag;
             UnleashApi = new Uri("http://localhost:4242/");
 
             UnleashApiClient = new MockApiClient();


### PR DESCRIPTION
# Description

Failing fetches should throw during synchronous initializations.
Introduces a way to get this done that should be forwards and backwards compatible, but has a small public signature change in the ApiClient used internally.

Fixes #210 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Added unit tests
- Ran existing tests

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules