### PR TITLE
feat: extend metrics with metadata

### DIFF
--- a/src/Unleash/Internal/UnleashServices.cs
+++ b/src/Unleash/Internal/UnleashServices.cs
@@ -16,7 +16,7 @@ namespace Unleash
         private readonly CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
         private readonly IUnleashScheduledTaskManager scheduledTaskManager;
 
-        const string supportedSpecVersion = "4.5.1";
+        public const string supportedSpecVersion = "4.5.1";
 
         internal CancellationToken CancellationToken { get; }
         internal IUnleashContextProvider ContextProvider { get; }
@@ -70,7 +70,7 @@ namespace Unleash
             }
             else
             {
-                // Mocked backend: fill instance collection 
+                // Mocked backend: fill instance collection
                 apiClient = settings.UnleashApiClient;
             }
 

--- a/src/Unleash/Metrics/ClientMetrics.cs
+++ b/src/Unleash/Metrics/ClientMetrics.cs
@@ -5,5 +5,34 @@ namespace Unleash.Metrics
         public string AppName { get; set; }
         public string InstanceId { get; set; }
         public MetricsBucket Bucket { get; set; }
+        public string PlatformName
+        {
+            get
+            {
+                return MetricsMetadata.GetPlatformName();
+
+            }
+        }
+        public string PlatformVersion
+        {
+            get
+            {
+                return MetricsMetadata.GetPlatformVersion();
+            }
+        }
+        public string YggdrasilVersion
+        {
+            get
+            {
+                return null;
+            }
+        }
+        public string SpecVersion
+        {
+            get
+            {
+                return UnleashServices.supportedSpecVersion;
+            }
+        }
     }
 }

--- a/src/Unleash/Metrics/ClientRegistration.cs
+++ b/src/Unleash/Metrics/ClientRegistration.cs
@@ -11,5 +11,34 @@ namespace Unleash.Metrics
         public List<string> Strategies { get; set; }
         public DateTimeOffset Started { get; set; }
         public long Interval { get; set; }
+        public string PlatformName
+        {
+            get
+            {
+                return MetricsMetadata.GetPlatformName();
+
+            }
+        }
+        public string PlatformVersion
+        {
+            get
+            {
+                return MetricsMetadata.GetPlatformVersion();
+            }
+        }
+        public string YggdrasilVersion
+        {
+            get
+            {
+                return null;
+            }
+        }
+        public string SpecVersion
+        {
+            get
+            {
+                return UnleashServices.supportedSpecVersion;
+            }
+        }
     }
 }

--- a/src/Unleash/Metrics/MetricsMetadata.cs
+++ b/src/Unleash/Metrics/MetricsMetadata.cs
@@ -1,0 +1,34 @@
+using System.Text.RegularExpressions;
+
+internal static class MetricsMetadata
+{
+    internal static string GetPlatformName()
+    {
+#if NETSTANDARD1_1_OR_GREATER || NETCOREAPP1_0_OR_GREATER
+        return GetPlatformName(System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription);
+#else
+            return "PreDotNetCore";
+#endif
+    }
+
+    internal static string GetPlatformName(string frameworkDescription)
+    {
+        var match = Regex.Match(frameworkDescription, @"^(?<name>.+?) \d");
+        return match.Success ? match.Groups["name"].Value : frameworkDescription;
+    }
+
+    internal static string GetPlatformVersion()
+    {
+#if NETSTANDARD1_1_OR_GREATER || NETCOREAPP1_0_OR_GREATER
+        return GetPlatformVersion(System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription);
+#else
+            return null;
+#endif
+    }
+
+    internal static string GetPlatformVersion(string frameworkDescription)
+    {
+        var match = Regex.Match(frameworkDescription, @"(\d+\.\d+\.\d+)");
+        return match.Success ? match.Value : null;
+    }
+}

--- a/tests/Unleash.Tests/Communication/UnleashApiClient_RegisterClient_Tests.cs
+++ b/tests/Unleash.Tests/Communication/UnleashApiClient_RegisterClient_Tests.cs
@@ -18,6 +18,10 @@ namespace Unleash.Tests.Communication
                 .WithPartialContent("\"interval\":1000")
                 .WithPartialContent("\"sdkVersion\":\"1.0.1\"")
                 .WithPartialContent("\"strategies\":[\"abc\"]")
+                .WithPartialContent("specVersion")
+                .WithPartialContent("platformName")
+                .WithPartialContent("platformVersion")
+                .WithPartialContent("\"yggdrasilVersion\":null")
                 .Respond("application/json", "{ 'status': 'ok' }");
 
             var clientRegistration = new ClientRegistration()

--- a/tests/Unleash.Tests/Communication/UnleashApiClient_SendMetrics_Tests.cs
+++ b/tests/Unleash.Tests/Communication/UnleashApiClient_SendMetrics_Tests.cs
@@ -19,6 +19,10 @@ namespace Unleash.Tests.Communication
                 .WithPartialContent("instanceId")
                 .WithPartialContent("\"no\":0")
                 .WithPartialContent("\"yes\":1")
+                .WithPartialContent("specVersion")
+                .WithPartialContent("platformName")
+                .WithPartialContent("platformVersion")
+                .WithPartialContent("\"yggdrasilVersion\":null")
                 .Respond("application/json", "{ 'status': 'ok' }");
 
             var metricsBucket = new ThreadSafeMetricsBucket();

--- a/tests/Unleash.Tests/Metrics/MetricsMetadataTests.cs
+++ b/tests/Unleash.Tests/Metrics/MetricsMetadataTests.cs
@@ -1,0 +1,17 @@
+using FluentAssertions;
+using NUnit.Framework;
+
+public class MetricsMetadataTests
+{
+    [TestCase(".NET Core 3.1.32", ".NET Core", "3.1.32")]
+    [TestCase(".NET 7.0.12", ".NET", "7.0.12")]
+    [TestCase(".NET", ".NET", null)] //apparently this can be a thing but the docs are very shady on when
+    public void GetPlatformName_ShouldReturnDotNet(string inputString, string expectedName, string expectedVersion)
+    {
+        var platformName = MetricsMetadata.GetPlatformName(inputString);
+        var platformVersion = MetricsMetadata.GetPlatformVersion(inputString);
+
+        platformName.Should().Be(expectedName);
+        platformVersion.Should().Be(expectedVersion);
+    }
+}


### PR DESCRIPTION
Needs #229, otherwise it'll be noisy

This adds metadata to the metrics and registration calls. This has a few sharp edges to it:

- Insofar as I can tell, there's no reliable way to get the version of the CLR or framework when running in C#. Everything has some details where it won't work on something. I've chosen to go with some degenerate string splitting + a compiler directive for older versions, which should give us enough information to know what's happening in the wild and always return "something"
- The design of the way async tasks work in this SDK needs to be rewritten to reduce the coupling between async stuff and business logic stuff. Right now there's no clean way to separate these two, which means there's no good way to extend the metrics/registration in a way that isn't imminently breakable from the consumer perspective or testable in any rational way. Because of this, I've chosen to make these properties lazy getters on the Metrics/Registration objects themselves because it's hard to accidentally break and it gives us some testing

The task system needs some love but I don't think it's responsible to do that before Yggdrasil gets merged