### PR TITLE
feat: always reset stream position after call to serializer

### DIFF
--- a/README.md
+++ b/README.md
@@ -533,7 +533,6 @@ public class NewtonsoftJson7Serializer : IJsonSerializer
             Serializer.Serialize(jsonWriter, instance);
 
             jsonWriter.Flush();
-			stream.Position = 0;
         }
     }
 

--- a/src/Unleash/Communication/UnleashApiClient.cs
+++ b/src/Unleash/Communication/UnleashApiClient.cs
@@ -187,6 +187,7 @@ namespace Unleash.Communication
 
             var memoryStream = new MemoryStream();
             jsonSerializer.Serialize(memoryStream, registration);
+            memoryStream.Position = 0;
 
             const int bufferSize = 1024 * 4;
 
@@ -233,6 +234,7 @@ namespace Unleash.Communication
                     InstanceId = clientRequestHeaders.InstanceTag,
                     Bucket = bucket
                 });
+                memoryStream.Position = 0;
             }
 
             const int bufferSize = 1024 * 4;


### PR DESCRIPTION
Resets stream position to 0 every time a call to serializer has been made.

Fixes #222 

Tested this locally, should work fine with existing code bases already calling stream.Position = 0 on their serializer implementations