### PR TITLE
chore: prepare for Yggdrasil with deprecations of changing API

### DIFF
--- a/src/Unleash/DefaultUnleash.cs
+++ b/src/Unleash/DefaultUnleash.cs
@@ -56,6 +56,7 @@ namespace Unleash
         ///// <param name="config">Unleash settings</param>
         ///// <param name="overrideDefaultStrategies">When true, it overrides the default strategies.</param>
         ///// <param name="strategies">Custom strategies.</param>
+        [Obsolete("Will be removed in the next major version", false)]
         public DefaultUnleash(UnleashSettings settings, bool overrideDefaultStrategies, params IStrategy[] strategies)
         {
             var currentInstanceNo = Interlocked.Increment(ref InitializedInstanceCount);
@@ -82,6 +83,7 @@ namespace Unleash
         }
 
         /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release", false)]
         public ICollection<FeatureToggle> FeatureToggles => services.ToggleCollection.Instance.Features;
 
         private EventCallbackConfig EventConfig { get; } = new EventCallbackConfig();
@@ -269,11 +271,13 @@ namespace Unleash
             return evaluationResult.Variant;
         }
 
+        [Obsolete("Will be removed in the next major version", false)]
         public IEnumerable<VariantDefinition> GetVariants(string toggleName)
         {
             return GetVariants(toggleName, services.ContextProvider.Context);
         }
 
+        [Obsolete("Will be removed in the next major version", false)]
         public IEnumerable<VariantDefinition> GetVariants(string toggleName, UnleashContext context)
         {
             if (!IsEnabled(toggleName, context)) return null;

--- a/src/Unleash/IUnleash.cs
+++ b/src/Unleash/IUnleash.cs
@@ -14,6 +14,7 @@ namespace Unleash
         /// <summary>
         /// Collection of currently loaded Feature Toggles
         /// </summary>
+        [Obsolete("Will be removed in the next major version", false)]
         ICollection<FeatureToggle> FeatureToggles { get; }
 
         /// <summary>
@@ -73,6 +74,7 @@ namespace Unleash
         /// </summary>
         /// <param name="toggleName">The name of the toggle.</param>
         /// <returns>A list of available variants.</returns>
+        [Obsolete("Will be removed in the next major version", false)]
         IEnumerable<VariantDefinition> GetVariants(string toggleName);
 
         /// <summary>
@@ -81,6 +83,7 @@ namespace Unleash
         /// <param name="toggleName">The name of the toggle.</param>
         /// /// <param name="context">The Unleash context to evaluate the toggle state against.</param>
         /// <returns>A list of available variants.</returns>
+        [Obsolete("Will be removed in the next major version", false)]
         IEnumerable<VariantDefinition> GetVariants(string toggleName, UnleashContext context);
 
         void ConfigureEvents(Action<EventCallbackConfig> config);

--- a/src/Unleash/Internal/IToggleBootstrapProvider.cs
+++ b/src/Unleash/Internal/IToggleBootstrapProvider.cs
@@ -6,6 +6,7 @@ namespace Unleash.Internal
 {
     public interface IToggleBootstrapProvider
     {
+        [Obsolete("Will return json string in the next major version", false)]
         ToggleCollection Read();
     }
 }

--- a/src/Unleash/Internal/IToggleBootstrapProvider.cs
+++ b/src/Unleash/Internal/IToggleBootstrapProvider.cs
@@ -6,7 +6,7 @@ namespace Unleash.Internal
 {
     public interface IToggleBootstrapProvider
     {
-        [Obsolete("Will return json string in the next major version", false)]
+        [Obsolete("Will be replaced in the next major version", false)]
         ToggleCollection Read();
     }
 }

--- a/src/Unleash/Utilities/ToggleBootstrapFileProvider.cs
+++ b/src/Unleash/Utilities/ToggleBootstrapFileProvider.cs
@@ -17,6 +17,7 @@ namespace Unleash.Utilities
             this.settings = settings;
         }
 
+        [Obsolete("Will return json string in the next major version", false)]
         public ToggleCollection Read()
         {
             using (var togglesStream = settings.FileSystem.FileOpenRead(filePath))

--- a/src/Unleash/Utilities/ToggleBootstrapFileProvider.cs
+++ b/src/Unleash/Utilities/ToggleBootstrapFileProvider.cs
@@ -17,7 +17,7 @@ namespace Unleash.Utilities
             this.settings = settings;
         }
 
-        [Obsolete("Will return json string in the next major version", false)]
+        [Obsolete("Will be replaced in the next major version", false)]
         public ToggleCollection Read()
         {
             using (var togglesStream = settings.FileSystem.FileOpenRead(filePath))

--- a/src/Unleash/Utilities/ToggleBootstrapUrlProvider.cs
+++ b/src/Unleash/Utilities/ToggleBootstrapUrlProvider.cs
@@ -30,8 +30,7 @@ namespace Unleash.Utilities
             this.throwOnFail = throwOnFail;
             this.customHeaders = customHeaders;
         }
-
-        [Obsolete("Will return json string in the next major version", false)]
+        [Obsolete("Will be replaced in the next major version", false)]
         public ToggleCollection Read()
         {
             return Task.Run(() => FetchFile()).GetAwaiter().GetResult();

--- a/src/Unleash/Utilities/ToggleBootstrapUrlProvider.cs
+++ b/src/Unleash/Utilities/ToggleBootstrapUrlProvider.cs
@@ -31,6 +31,7 @@ namespace Unleash.Utilities
             this.customHeaders = customHeaders;
         }
 
+        [Obsolete("Will return json string in the next major version", false)]
         public ToggleCollection Read()
         {
             return Task.Run(() => FetchFile()).GetAwaiter().GetResult();


### PR DESCRIPTION
Deprecations in preparation of [Yggdrasil PR](https://github.com/Unleash/unleash-client-dotnet/pull/224) that removes some public APIs