### PR TITLE
chore: use method signature overloads instead of dynamic in scheduler

### DIFF
--- a/src/Unleash/Internal/UnleashExtensions.cs
+++ b/src/Unleash/Internal/UnleashExtensions.cs
@@ -32,14 +32,34 @@ namespace Unleash.Internal
             }
         }
 
-        internal static void SafeTimerChange(this Timer timer, dynamic dueTime, dynamic period, ref bool disposeEnded)
+        internal static void SafeTimerChange(this Timer timer, int dueTime, int period, ref bool disposeEnded)
         {
-            if (dueTime.GetType() != period.GetType())
-                throw new Exception("Data types has to match. (Int32 or TimeSpan)");
+            try
+            {
+                timer?.Change(dueTime, period);
+            }
+            catch (ObjectDisposedException)
+            {
+                // race condition with Dispose can cause trigger to be called when underlying
+                // timer is being disposed - and a change will fail in this case.
+                // see
+                // https://msdn.microsoft.com/en-us/library/b97tkt95(v=vs.110).aspx#Anchor_2
+                if (disposeEnded)
+                {
+                    // we still want to throw the exception in case someone really tries
+                    // to change the timer after disposal has finished
+                    // of course there's a slight race condition here where we might not
+                    // throw even though disposal is already done.
+                    // since the offending code would most likely already be "failing"
+                    // unreliably i personally can live with increasing the
+                    // "unreliable failure" time-window slightly
+                    throw;
+                }
+            }
+        }
 
-            if (!(dueTime.GetType() != typeof(int) || dueTime.GetType() != typeof(TimeSpan)))
-                throw new Exception("Only System.Int32 or System.TimeSpan");
-
+        internal static void SafeTimerChange(this Timer timer, TimeSpan dueTime, TimeSpan period, ref bool disposeEnded)
+        {
             try
             {
                 timer?.Change(dueTime, period);


### PR DESCRIPTION
Removes the dynamic parameters and their required type checks from the scheduler extensions and replaces with overloads for the two types we do expect as parameters: int and TimeSpan