### PR TITLE
chore: deprecate no longer supported projectId and environment config settings

### DIFF
--- a/src/Unleash/UnleashSettings.cs
+++ b/src/Unleash/UnleashSettings.cs
@@ -43,6 +43,7 @@ namespace Unleash
         /// <summary>
         /// Gets or sets an environment. Used for communication with backend api.
         /// </summary>
+        [Obsolete("No longer supported in recent versions of Unleash, scope API token accordingly instead. Will be removed in the next major version", false)]
         public string Environment { get; set; } = "default";
 
         /// <summary>
@@ -53,6 +54,7 @@ namespace Unleash
         /// <summary>
         /// Sets the project to fetch feature toggles for.
         /// </summary>
+        [Obsolete("No longer supported in recent versions of Unleash, scope API token accordingly instead. Will be removed in the next major version", false)]
         public string ProjectId { get; set; } = null;
 
         /// <summary>


### PR DESCRIPTION
Deprecates ProjectId and Environment properties of UnleashSettings with an upcoming removal notice and gentle push towards API token scopes. 