### PR TITLE
chore: change some header levels in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -571,7 +571,7 @@ Tests live in `./tests/Unleash.Tests`
 - Build: `dotnet build`
 - Test: `dotnet test` - This also executes spec tests
 
-## Formatting
+### Formatting
 
 We enforce formatting with `dotnet format`. This can be installed using the following command:
 
@@ -587,6 +587,6 @@ We enforce formatting with `dotnet format`. This can be installed using the foll
 - Click `Publish release`.
 This starts the release workflow which builds the new release and pushes the artifacts to NuGet
 
-### Other information
+## Other information
 
 - Check out our guide for more information on how to build and scale [feature flag](https://docs.getunleash.io/topics/feature-flags/feature-flag-best-practices) systems


### PR DESCRIPTION
The formatting header was its own top-level header with "release
process" nested under it. I'm assuming it should've been one level
deeper (the same as release process).

Also, "other information" isn't really development stuff, so let's
raise it.