### PR TITLE
Fix currentTime constraint when CurrentTime is not explicitly set

### DIFF
--- a/src/Unleash/UnleashContext.cs
+++ b/src/Unleash/UnleashContext.cs
@@ -46,6 +46,8 @@ namespace Unleash
                     return SessionId;
                 case "remoteAddress":
                     return RemoteAddress;
+                case "currentTime":
+                    return (CurrentTime ?? DateTimeOffset.UtcNow).ToString("O");
                 default:
                     string result;
                     Properties.TryGetValue(contextName, out result);

--- a/tests/Unleash.Tests/Strategy/Constraints/DateConstraintOperator_Tests.cs
+++ b/tests/Unleash.Tests/Strategy/Constraints/DateConstraintOperator_Tests.cs
@@ -147,5 +147,35 @@ namespace Unleash.Tests.Strategy.Constraints
             // Assert
             result.Should().BeTrue();
         }
+
+        [Test]
+        public void DATE_AFTER_CurrentTime()
+        {
+            // Arrange
+            var target = new DateConstraintOperator();
+            var constraint = new Constraint("currentTime", Operator.DATE_AFTER, false, false, DateTime.UtcNow.AddDays(-30).ToString("O"));
+            var context = new UnleashContext.Builder().Now().Build();
+
+            // Act
+            var result = target.Evaluate(constraint, context);
+
+            // Assert
+            result.Should().BeTrue();
+        }
+
+        [Test]
+        public void DATE_AFTER_CurrentTime_Not_Set_Uses_UtcNow()
+        {
+            // Arrange
+            var target = new DateConstraintOperator();
+            var constraint = new Constraint("currentTime", Operator.DATE_AFTER, false, false, DateTime.UtcNow.AddDays(-30).ToString("O"));
+            var context = new UnleashContext();
+
+            // Act
+            var result = target.Evaluate(constraint, context);
+
+            // Assert
+            result.Should().BeTrue();
+        }
     }
 }

--- a/tests/Unleash.Tests/UnleashContextTests.cs
+++ b/tests/Unleash.Tests/UnleashContextTests.cs
@@ -82,5 +82,27 @@ namespace Unleash.Tests
             enhancedContext.AppName.Should().Be("myapp");
             enhancedContext.Properties["test"].Should().Be("me");
         }
+
+        [Test]
+        public void GetByName_Should_Return_CurrentTime_For_currentTime_Context_Name()
+        {
+            var date = new DateTimeOffset(2024, 10, 23, 15, 0, 0, TimeSpan.FromHours(-4));
+            var context = new UnleashContext.Builder()
+                .CurrentTime(date)
+                .Build();
+
+            var value = context.GetByName("currentTime");
+            value.Should().Be(date.ToString("O"));
+        }
+
+        [Test]
+        public void GetByName_Should_Return_UtcNow_For_currentTime_Context_Name_When_CurrentTime_Is_Not_Set()
+        {
+            var context = new UnleashContext();
+
+            var value = context.GetByName("currentTime");
+            var parsedValue = DateTimeOffset.Parse(value);
+            parsedValue.Should().BeLessThan(TimeSpan.FromSeconds(1)).Before(DateTimeOffset.UtcNow);
+        }
     }
 }


### PR DESCRIPTION
# Description

Change `UnleashContext.GetByName` to return `CurrentTime` when `contextName` is `"currentTime"` (or `DateTimeOffset.UtcNow` when `UnleashContext.CurrentTime` is not set).

Also, I suspect the `else` branch of `if (!string.IsNullOrWhiteSpace(contextValue))` in `DateConstraintOperator.Evaluate` is wrong: I don't see why we would use `context.CurrentTime` if there is no value for the `ContextName` specified in the constraint. It should only be done if the `ContextName` is `"currentTime"` (but it would be redundant anyway after my change). I think that whole `else` branch should be removed. I didn't make that change yet, wanted to check with you guys first.

Fixes #245

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Unit tests

**Test Configuration**:
* Firmware version: not relevant
* Hardware: not relevant
* Toolchain: not relevant
* SDK: .NET SDK 8.0.403

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules