### PR TITLE
chore: remove unnecessary else branch in date constraint

### DIFF
--- a/src/Unleash/Strategies/Constraints/DateConstraintOperator.cs
+++ b/src/Unleash/Strategies/Constraints/DateConstraintOperator.cs
@@ -14,19 +14,11 @@ namespace Unleash.Strategies.Constraints
 
             var contextValue = context.GetByName(constraint.ContextName);
             DateTimeOffset? contextDate;
-            if (!string.IsNullOrWhiteSpace(contextValue))
-            {
-                if (!DateTimeOffset.TryParse(contextValue, out var date))
-                    return false;
-                else
-                    contextDate = date;
-            }
+
+            if (!DateTimeOffset.TryParse(contextValue, out var date))
+                return false;
             else
-            {
-                contextDate = context.CurrentTime;
-                if (!contextDate.HasValue)
-                    return false;
-            }
+                contextDate = date;
 
             if (constraint.Inverted)
                 return !Eval(constraint.Operator, constraintDate, contextDate.Value);


### PR DESCRIPTION
This just removes the `else` statement code here and makes the `if` the only code path.

The `else` is now redundant, based on this PR #246 which forces the context to always have a current time 