### PR TITLE
feat: allow for listing the flags known to the SDK

### DIFF
--- a/src/Unleash/DefaultUnleash.cs
+++ b/src/Unleash/DefaultUnleash.cs
@@ -3,6 +3,8 @@ namespace Unleash
     using Internal;
     using Logging;
     using System;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
     using System.Threading;
     using Unleash.Utilities;
@@ -83,6 +85,11 @@ namespace Unleash
             return enabled;
         }
 
+        public ICollection<ToggleDefinition> ListKnownToggles()
+        {
+            return services.engine.ListKnownToggles().Select(ToggleDefinition.FromYggdrasilDef).ToList();
+        }
+
         public Variant GetVariant(string toggleName)
         {
             return GetVariant(toggleName, services.ContextProvider.Context, Variant.DISABLED_VARIANT);
@@ -115,7 +122,7 @@ namespace Unleash
 
             if (services.engine.ShouldEmitImpressionEvent(toggleName))
             {
-                EmitImpressionEvent("getVariant", enhancedContext, variant.IsEnabled, toggleName, variant.Name);
+                EmitImpressionEvent("getVariant", enhancedContext, variant.Enabled, toggleName, variant.Name);
             }
 
             return Variant.UpgradeVariant(variant);

--- a/src/Unleash/IUnleash.cs
+++ b/src/Unleash/IUnleash.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using Unleash.Internal;
 
 namespace Unleash
@@ -60,6 +61,14 @@ namespace Unleash
         /// <param name="defaultValue">If a toggle is not found, the default value will be returned.</param>
         /// <returns>A weighted variant or the supplied default value if feature is not available</returns>
         Variant GetVariant(string toggleName, UnleashContext context, Variant defaultValue);
+
+        /// <summary>
+        /// Lists all the feature flags currently known to the SDK. Dependent on what toggles
+        /// the used API key has access to. If the client has been bootstrapped but not yet
+        /// fetched from upstream, the returned list will match the bootstrap.
+        /// </summary>
+        /// <returns>A list of metadata about known feature flags</returns>
+        ICollection<ToggleDefinition> ListKnownToggles();
 
         void ConfigureEvents(Action<EventCallbackConfig> config);
     }

--- a/src/Unleash/Internal/ToggleDefinition.cs
+++ b/src/Unleash/Internal/ToggleDefinition.cs
@@ -1,0 +1,21 @@
+using Yggdrasil;
+
+public class ToggleDefinition
+{
+    public ToggleDefinition(string name, string project, string type)
+    {
+        Name = name;
+        Project = project;
+        Type = type;
+    }
+    public string Name { get; private set; }
+
+    public string Project { get; private set; }
+
+    public string Type { get; private set; }
+
+    internal static ToggleDefinition FromYggdrasilDef(FeatureDefinition definition)
+    {
+        return new ToggleDefinition(definition.Name, definition.Project, definition.Type);
+    }
+}

--- a/src/Unleash/Internal/UnleashServices.cs
+++ b/src/Unleash/Internal/UnleashServices.cs
@@ -17,7 +17,7 @@ namespace Unleash
         private readonly CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
         private readonly IUnleashScheduledTaskManager scheduledTaskManager;
 
-        public const string supportedSpecVersion = "4.5.1";
+        public const string supportedSpecVersion = "5.1.7";
 
         internal CancellationToken CancellationToken { get; }
         internal IUnleashContextProvider ContextProvider { get; }

--- a/src/Unleash/Internal/Variant.cs
+++ b/src/Unleash/Internal/Variant.cs
@@ -11,7 +11,7 @@
 
         internal static Variant UpgradeVariant(Yggdrasil.Variant variant)
         {
-            return new Variant(variant.Name, variant.Payload, variant.IsEnabled, variant.FeatureEnabled);
+            return new Variant(variant.Name, variant.Payload, variant.Enabled, variant.FeatureEnabled);
         }
     }
 }

--- a/src/Unleash/Unleash.csproj
+++ b/src/Unleash/Unleash.csproj
@@ -72,7 +72,7 @@
     <PackageReference Include="murmurhash" Version="1.0.3" />
     <PackageReference Include="NuGet.Versioning" Version="6.1.0" />
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="Unleash.Yggdrasil" Version="1.0.0-beta.3" />
+    <PackageReference Include="Unleash.Yggdrasil" Version="1.0.0-beta.8" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Unleash.Tests/DefaultUnleashTests.cs
+++ b/tests/Unleash.Tests/DefaultUnleashTests.cs
@@ -94,5 +94,18 @@ namespace Unleash.Tests
 
             return unleash;
         }
+
+        [Test]
+        public void ListingKnownFlagsReturnsFullList()
+        {
+            // Arrange
+            var unleash = CreateUnleash("testapp", "{\"version\":1,\"features\":[{\"name\":\"test-flag\",\"enabled\":true,\"strategies\":[{\"name\":\"default\"}]}]}");
+
+            // Act
+            var flags = unleash.ListKnownToggles();
+
+            // Assert
+            flags.First().Name.Should().Be("test-flag");
+        }
     }
 }

--- a/tests/Unleash.Tests/Integration/ClientSpecificationTests.cs
+++ b/tests/Unleash.Tests/Integration/ClientSpecificationTests.cs
@@ -30,7 +30,7 @@ namespace Unleash.Tests.Specifications
 
             using (var client = new HttpClient())
             {
-                var csTestsVersion = "v5.1.4";
+                var csTestsVersion = "v5.1.7";
                 var indexPath = $"https://raw.githubusercontent.com/Unleash/client-specification/{csTestsVersion}/specifications/";
                 var indexResponse = client.GetStringAsync(indexPath + "index.json").Result;
                 var indexFilePath = Path.Combine(specificationsPath, "index.json");
@@ -119,7 +119,7 @@ namespace Unleash.Tests.Specifications
 
                 // Assert
                 Assert.That(result.Name, Is.EqualTo(testCase.ExpectedResult.Name), testCase.Description);
-                Assert.That(result.IsEnabled, Is.EqualTo(testCase.ExpectedResult.IsEnabled), testCase.Description);
+                Assert.That(result.Enabled, Is.EqualTo(testCase.ExpectedResult.Enabled), testCase.Description);
                 Assert.That(result.FeatureEnabled, Is.EqualTo(testCase.ExpectedResult.FeatureEnabled), testCase.Description);
                 Assert.That(result.Payload, Is.EqualTo(testCase.ExpectedResult.Payload), testCase.Description);
             };

--- a/tests/Unleash.Tests/Integration/ClientSpecificationTests.cs
+++ b/tests/Unleash.Tests/Integration/ClientSpecificationTests.cs
@@ -30,8 +30,7 @@ namespace Unleash.Tests.Specifications
 
             using (var client = new HttpClient())
             {
-                var csTestsVersion = "v5.1.7";
-                var indexPath = $"https://raw.githubusercontent.com/Unleash/client-specification/{csTestsVersion}/specifications/";
+                var indexPath = $"https://raw.githubusercontent.com/Unleash/client-specification/v{UnleashServices.supportedSpecVersion}/specifications/";
                 var indexResponse = client.GetStringAsync(indexPath + "index.json").Result;
                 var indexFilePath = Path.Combine(specificationsPath, "index.json");
                 if (File.Exists(indexFilePath))

--- a/tests/Unleash.Tests/Integration/TestCaseVariant.cs
+++ b/tests/Unleash.Tests/Integration/TestCaseVariant.cs
@@ -4,15 +4,9 @@ namespace Unleash.Tests.Specifications
 {
     public class TestCaseVariant
     {
-        private Variant _expectedResult;
-
         public string Description { get; set; }
         public UnleashContextDefinition Context { get; set; }
         public string ToggleName { get; set; }
-        public Variant ExpectedResult
-        {
-            set => _expectedResult = value;
-            get => _expectedResult?.Name.Equals("disabled") == true ? Variant.DISABLED_VARIANT : _expectedResult;
-        }
+        public Variant ExpectedResult { get; set; }
     }
 }


### PR DESCRIPTION
Adds a method to list the features known to the SDK. This is intended to replace the legacy option to access the feature flags directly, which is typically used to iterate the known flags and evaluate them all

There's a bunch of noise her moving from `IsEnabled` to `Enabled` in the engine but that's all internal

Also fixes the client spec header because that's wantonly out of sync at this point