### PR TITLE
chore: only send the JSON header once when sending metrics and registration

### DIFF
--- a/src/Unleash/Communication/UnleashApiClient.cs
+++ b/src/Unleash/Communication/UnleashApiClient.cs
@@ -190,7 +190,6 @@ namespace Unleash.Communication
             using (var request = new HttpRequestMessage(HttpMethod.Post, requestUri))
             {
                 request.Content = new StringContent(JsonSerializer.Serialize(registration, options), Encoding.UTF8, "application/json");
-                request.Content.Headers.AddContentTypeJson();
 
                 SetRequestHeaders(request, clientRequestHeaders);
 
@@ -230,7 +229,6 @@ namespace Unleash.Communication
             using (var request = new HttpRequestMessage(HttpMethod.Post, requestUri))
             {
                 request.Content = new StringContent(JsonSerializer.Serialize(clientMetrics, options), Encoding.UTF8, "application/json");
-                request.Content.Headers.AddContentTypeJson();
 
                 SetRequestHeaders(request, clientRequestHeaders);
 


### PR DESCRIPTION
Sending this multiple times breaks the Unleash header validation and metrics/registration get rejected