### PR TITLE
chore: swap out leaky yggdrasil custom strategy for an internal abstraction

### DIFF
--- a/samples/DotnetCore/Program.cs
+++ b/samples/DotnetCore/Program.cs
@@ -1,6 +1,6 @@
 ﻿using Unleash;
 using Unleash.ClientFactory;
-using Unleash.Internal;
+using Unleash.Strategies;
 
 var settings = new UnleashSettings()
 {
@@ -8,7 +8,7 @@ var settings = new UnleashSettings()
     UnleashApi = new Uri("http://localhost:4242/api"), //setup for running against a local unleash instance, feel free to change this
     CustomHttpHeaders = new Dictionary<string, string>()
     {
-      {"Authorization","add a valid client token here" }
+      {"Authorization","*:development.86efeeed04ed49e6389fe848925289475b89996404c320154437d8e0" }
     },
     SendMetricsInterval = TimeSpan.FromSeconds(1)
 };
@@ -18,7 +18,7 @@ const string TOGGLE_NAME = "test";
 Console.WriteLine("Starting Unleash SDK");
 
 var unleashFactory = new UnleashClientFactory();
-IUnleash unleash = await unleashFactory.CreateClientAsync(settings, synchronousInitialization: true);
+IUnleash unleash = await unleashFactory.CreateClientAsync(settings, synchronousInitialization: true, new MyCustomStrategy());
 
 
 while (true)
@@ -28,4 +28,14 @@ while (true)
 
     Console.WriteLine($"Toggle enabled: {enabled}, variant: {System.Text.Json.JsonSerializer.Serialize(variant)}");
     await Task.Delay(1000);
+}
+
+class MyCustomStrategy : IStrategy
+{
+    public string Name => "my-custom-strategy";
+
+    public bool IsEnabled(Dictionary<string, string> parameters, UnleashContext context)
+    {
+        return true;
+    }
 }

--- a/samples/DotnetCore/Program.cs
+++ b/samples/DotnetCore/Program.cs
@@ -8,7 +8,7 @@ var settings = new UnleashSettings()
     UnleashApi = new Uri("http://localhost:4242/api"), //setup for running against a local unleash instance, feel free to change this
     CustomHttpHeaders = new Dictionary<string, string>()
     {
-      {"Authorization","*:development.86efeeed04ed49e6389fe848925289475b89996404c320154437d8e0" }
+      {"Authorization","add a valid client token here" }
     },
     SendMetricsInterval = TimeSpan.FromSeconds(1)
 };
@@ -30,6 +30,8 @@ while (true)
     await Task.Delay(1000);
 }
 
+// If you want to test this, you'll need to setup a custom strategy in your
+// Unleash UI and add it to the 'test' toggle.
 class MyCustomStrategy : IStrategy
 {
     public string Name => "my-custom-strategy";

--- a/src/Unleash/ClientFactory/IUnleashClientFactory.cs
+++ b/src/Unleash/ClientFactory/IUnleashClientFactory.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading.Tasks;
+using Unleash.Strategies;
 
 namespace Unleash.ClientFactory
 {

--- a/src/Unleash/ClientFactory/IUnleashClientFactory.cs
+++ b/src/Unleash/ClientFactory/IUnleashClientFactory.cs
@@ -1,5 +1,4 @@
 ﻿using System.Threading.Tasks;
-using Yggdrasil;
 
 namespace Unleash.ClientFactory
 {

--- a/src/Unleash/ClientFactory/UnleashClientFactory.cs
+++ b/src/Unleash/ClientFactory/UnleashClientFactory.cs
@@ -1,6 +1,6 @@
 ﻿using System.Threading;
 using System.Threading.Tasks;
-using Yggdrasil;
+using Unleash.Strategies;
 
 namespace Unleash.ClientFactory
 {
@@ -14,7 +14,7 @@ namespace Unleash.ClientFactory
                           TaskScheduler.Default);
 
         /// <summary>
-        /// Initializes a new instance of Unleash client. 
+        /// Initializes a new instance of Unleash client.
         /// </summary>
         /// <param name="synchronousInitialization">If true, fetch and cache toggles before returning. If false, allow the unleash client schedule an initial poll of features in the background</param>
         /// <param name="strategies">Custom strategies, added in addtion to builtIn strategies.</param>
@@ -38,7 +38,7 @@ namespace Unleash.ClientFactory
 
 
         /// <summary>
-        /// Initializes a new instance of Unleash client. 
+        /// Initializes a new instance of Unleash client.
         /// </summary>
         /// <param name="synchronousInitialization">If true, fetch and cache toggles before returning. If false, allow the unleash client schedule an initial poll of features in the background</param>
         /// <param name="strategies">Custom strategies, added in addtion to builtIn strategies.</param>

--- a/src/Unleash/DefaultUnleash.cs
+++ b/src/Unleash/DefaultUnleash.cs
@@ -6,6 +6,7 @@ namespace Unleash
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading;
+    using Unleash.Strategies;
     using Unleash.Utilities;
 
     /// <inheritdoc />

--- a/src/Unleash/DefaultUnleash.cs
+++ b/src/Unleash/DefaultUnleash.cs
@@ -3,7 +3,6 @@ namespace Unleash
     using Internal;
     using Logging;
     using System;
-    using System.Collections;
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading;
@@ -29,7 +28,7 @@ namespace Unleash
         ///// </summary>
         ///// <param name="config">Unleash settings</param>
         ///// <param name="strategies">Custom strategies.</param>
-        public DefaultUnleash(UnleashSettings settings, params Yggdrasil.IStrategy[] strategies)
+        public DefaultUnleash(UnleashSettings settings, params IStrategy[] strategies)
         {
             var currentInstanceNo = Interlocked.Increment(ref InitializedInstanceCount);
 

--- a/src/Unleash/Internal/UnleashServices.cs
+++ b/src/Unleash/Internal/UnleashServices.cs
@@ -42,7 +42,9 @@ namespace Unleash
                 settings.FileSystem = new FileSystem(settings.Encoding);
             }
 
-            engine = new YggdrasilEngine(strategies);
+            List<Yggdrasil.IStrategy> yggdrasilStrategies = strategies?.Cast<Yggdrasil.IStrategy>().ToList();
+
+            engine = new YggdrasilEngine(yggdrasilStrategies);
 
             var backupFile = settings.GetFeatureToggleFilePath();
             var etagBackupFile = settings.GetFeatureToggleETagFilePath();

--- a/src/Unleash/Internal/UnleashServices.cs
+++ b/src/Unleash/Internal/UnleashServices.cs
@@ -7,6 +7,7 @@ using Unleash.Events;
 using Unleash.Internal;
 using Unleash.Logging;
 using Unleash.Scheduling;
+using Unleash.Strategies;
 using Yggdrasil;
 
 namespace Unleash
@@ -35,14 +36,14 @@ namespace Unleash
             "userWithId"
         };
 
-        public UnleashServices(UnleashSettings settings, EventCallbackConfig eventConfig, List<IStrategy> strategies = null)
+        public UnleashServices(UnleashSettings settings, EventCallbackConfig eventConfig, List<Strategies.IStrategy> strategies = null)
         {
             if (settings.FileSystem == null)
             {
                 settings.FileSystem = new FileSystem(settings.Encoding);
             }
 
-            List<Yggdrasil.IStrategy> yggdrasilStrategies = strategies?.Cast<Yggdrasil.IStrategy>().ToList();
+            List<Yggdrasil.IStrategy> yggdrasilStrategies = strategies?.Select(s => new CustomStrategyAdapter(s)).Cast<Yggdrasil.IStrategy>().ToList();
 
             engine = new YggdrasilEngine(yggdrasilStrategies);
 

--- a/src/Unleash/Strategies/IStrategy.cs
+++ b/src/Unleash/Strategies/IStrategy.cs
@@ -1,3 +1,53 @@
-public interface IStrategy : Yggdrasil.IStrategy
+using System;
+using Yggdrasil;
+
+
+namespace Unleash.Strategies
 {
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// Defines a strategy for enabling a feature.
+    /// </summary>
+    public interface IStrategy
+    {
+        /// <summary>
+        /// Gets the strategy name
+        /// </summary>
+        string Name { get; }
+
+        /// <summary>
+        /// Calculates if the strategy is enabled for a given context
+        /// </summary>
+        bool IsEnabled(Dictionary<string, string> parameters, UnleashContext context);
+    }
+
+    internal class CustomStrategyAdapter : Yggdrasil.IStrategy
+    {
+        private IStrategy strategy { get; }
+
+        public CustomStrategyAdapter(IStrategy strategy)
+        {
+            this.strategy = strategy;
+        }
+
+        public string Name => strategy.Name;
+
+        public bool IsEnabled(Dictionary<string, string> parameters, Context context)
+        {
+            var currentTime = context.CurrentTime ?? DateTimeOffset.UtcNow;
+
+            var unleashContext = new UnleashContext.Builder()
+                                                    .AppName(context.AppName)
+                                                    .CurrentTime(currentTime)
+                                                    .Environment(context.Environment)
+                                                    .UserId(context.UserId)
+                                                    .SessionId(context.SessionId)
+                                                    .RemoteAddress(context.RemoteAddress)
+                                                    .Build();
+            unleashContext.Properties = context.Properties;
+
+            return strategy.IsEnabled(parameters, unleashContext);
+        }
+    }
 }

--- a/src/Unleash/Strategies/IStrategy.cs
+++ b/src/Unleash/Strategies/IStrategy.cs
@@ -1,0 +1,3 @@
+public interface IStrategy : Yggdrasil.IStrategy
+{
+}


### PR DESCRIPTION
Adds an adaptor for Yggdrasil ->  Legacy strategies so we don't have to leak out Yggdrasil abstractions. The barebones interface doesn't work because the method signature requires an Yggdrasil type - the Context.

Not tested automatically because it's all just plumbing but most of the existing tests already cover the Unleash constructor and manually tested through the example project