### PR TITLE
fix: send default buckets instead of null metrics buckets as they cause 400s

### DIFF
--- a/src/Unleash/Communication/UnleashApiClient.cs
+++ b/src/Unleash/Communication/UnleashApiClient.cs
@@ -223,7 +223,7 @@ namespace Unleash.Communication
             {
                 AppName = clientRequestHeaders.AppName,
                 InstanceId = clientRequestHeaders.InstanceTag,
-                Bucket = metrics
+                Bucket = metrics ?? new Yggdrasil.MetricsBucket(new Dictionary<string, Yggdrasil.FeatureCount>(), DateTimeOffset.UtcNow, DateTimeOffset.UtcNow)
             };
 
             using (var request = new HttpRequestMessage(HttpMethod.Post, requestUri))


### PR DESCRIPTION
Initializes a metric bucket with default values if the send metrics bucket comes back as null from the engine.
This lets us keep metrics as a heartbeat even when buckets are empty

This does not introduce the 10min hold off that Ruby does. Should it?