### PR TITLE
fix: support for utf-8 chars on win

### DIFF
--- a/src/Unleash/Internal/UnleashServices.cs
+++ b/src/Unleash/Internal/UnleashServices.cs
@@ -18,7 +18,7 @@ namespace Unleash
         private readonly CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
         private readonly IUnleashScheduledTaskManager scheduledTaskManager;
 
-        public const string supportedSpecVersion = "5.1.7";
+        public const string supportedSpecVersion = "5.1.9";
 
         internal CancellationToken CancellationToken { get; }
         internal IUnleashContextProvider ContextProvider { get; }


### PR DESCRIPTION
https://linear.app/unleash/issue/2-3110/net-sdk-utf-8-scandinavian-character-issue

Adds support for flag names with valid UTF-8 characters like `ø` when running on Windows.

> WIP