### PR TITLE
feat: client identification headers

### DIFF
--- a/src/Unleash/Communication/UnleashApiClient.cs
+++ b/src/Unleash/Communication/UnleashApiClient.cs
@@ -274,12 +274,20 @@ namespace Unleash.Communication
             const string userAgentHeader = "User-Agent";
             const string instanceIdHeader = "UNLEASH-INSTANCEID";
 
+            const string identifyConnectionHeader = "x-unleash-connection-id";
+            const string identifyAppNameHeader = "x-unleash-appname";
+            const string identifySdkHeader = "x-unleash-sdk";
+
             const string supportedSpecVersionHeader = "Unleash-Client-Spec";
 
             requestMessage.Headers.TryAddWithoutValidation(appNameHeader, headers.AppName);
             requestMessage.Headers.TryAddWithoutValidation(userAgentHeader, headers.AppName);
             requestMessage.Headers.TryAddWithoutValidation(instanceIdHeader, headers.InstanceTag);
             requestMessage.Headers.TryAddWithoutValidation(supportedSpecVersionHeader, headers.SupportedSpecVersion);
+
+            requestMessage.Headers.TryAddWithoutValidation(identifyConnectionHeader, headers.ConnectionId);
+            requestMessage.Headers.TryAddWithoutValidation(identifyAppNameHeader, headers.AppName);
+            requestMessage.Headers.TryAddWithoutValidation(identifySdkHeader, headers.SdkVersion);
 
             SetCustomHeaders(requestMessage, headers.CustomHttpHeaders);
             SetCustomHeaders(requestMessage, headers.CustomHttpHeaderProvider?.CustomHeaders);

--- a/src/Unleash/Communication/UnleashApiClientRequestHeaders.cs
+++ b/src/Unleash/Communication/UnleashApiClientRequestHeaders.cs
@@ -6,6 +6,8 @@ namespace Unleash.Communication
     {
         public string AppName { get; set; }
         public string InstanceTag { get; set; }
+        public string ConnectionId { get; internal set; }
+        public string SdkVersion { get; set; }
         public Dictionary<string, string> CustomHttpHeaders { get; set; }
         public IUnleashCustomHttpHeaderProvider CustomHttpHeaderProvider { get; set; }
         public string SupportedSpecVersion { get; internal set; }

--- a/src/Unleash/Internal/UnleashServices.cs
+++ b/src/Unleash/Internal/UnleashServices.cs
@@ -17,6 +17,7 @@ namespace Unleash
         private static readonly ILog Logger = LogProvider.GetLogger(typeof(UnleashServices));
         private readonly CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
         private readonly IUnleashScheduledTaskManager scheduledTaskManager;
+        private readonly string connectionId = Guid.NewGuid().ToString();
 
         public const string supportedSpecVersion = "5.1.9";
 
@@ -84,6 +85,8 @@ namespace Unleash
                 {
                     AppName = settings.AppName,
                     InstanceTag = settings.InstanceTag,
+                    ConnectionId = connectionId,
+                    SdkVersion = settings.SdkVersion,
                     CustomHttpHeaders = settings.CustomHttpHeaders,
                     CustomHttpHeaderProvider = settings.UnleashCustomHttpHeaderProvider,
                     SupportedSpecVersion = supportedSpecVersion

--- a/src/Unleash/UnleashSettings.cs
+++ b/src/Unleash/UnleashSettings.cs
@@ -146,7 +146,7 @@ namespace Unleash
             var assemblyName = Assembly.GetExecutingAssembly().GetName();
             var version = assemblyName.Version.ToString(3);
 
-            return $"unleash-client-dotnet:v{version}";
+            return $"unleash-client-dotnet:{version}";
         }
 
         private static string GetDefaultInstanceTag()

--- a/tests/Unleash.Tests/Communication/CustomHeadersUnitTest.cs
+++ b/tests/Unleash.Tests/Communication/CustomHeadersUnitTest.cs
@@ -135,5 +135,31 @@ namespace Unleash.Tests.Communication
             }
         }
 
+        [Test]
+        public async Task IdentificationHttpHeaders()
+        {
+            api = CreateApiClient();
+            var engine = new YggdrasilEngine();
+
+            var etag = "";
+            await api.FetchToggles(etag, CancellationToken.None);
+            await api.RegisterClient(new Unleash.Metrics.ClientRegistration(), CancellationToken.None);
+            await api.SendMetrics(engine.GetMetrics(), CancellationToken.None);
+
+            messageHandler.calls.Count.Should().Be(3);
+            foreach (var call in messageHandler.calls)
+            {
+                call.Headers.Should().ContainEquivalentOf(
+                    new KeyValuePair<string, IEnumerable<string>>("x-unleash-connection-id", new string[] { "00000000-0000-4000-a000-000000000000" })
+                );
+                call.Headers.Should().ContainEquivalentOf(
+                    new KeyValuePair<string, IEnumerable<string>>("x-unleash-appname", new string[] { "api-test-client" })
+                );
+                call.Headers.Should().ContainEquivalentOf(
+                    new KeyValuePair<string, IEnumerable<string>>("x-unleash-sdk", new string[] { "unleash-client-mock:0.0.0" })
+                );
+            }
+        }
+
     }
 }

--- a/tests/Unleash.Tests/Communication/CustomHeadersUnitTest.cs
+++ b/tests/Unleash.Tests/Communication/CustomHeadersUnitTest.cs
@@ -16,6 +16,8 @@ namespace Unleash.Tests.Communication
             {
                 AppName = "api-test-client",
                 InstanceTag = "instance1",
+                ConnectionId = "00000000-0000-4000-a000-000000000000",
+                SdkVersion = "unleash-client-mock:0.0.0",
                 CustomHttpHeaders = httpHeaders,
                 CustomHttpHeaderProvider = httpHeadersProvider
             };

--- a/tests/Unleash.Tests/Communication/MockHttpClient.cs
+++ b/tests/Unleash.Tests/Communication/MockHttpClient.cs
@@ -18,6 +18,8 @@ namespace Unleash.Tests.Communication
             var requestHeaders = new UnleashApiClientRequestHeaders
             {
                 AppName = "api-test-client",
+                ConnectionId = "00000000-0000-4000-a000-000000000000",
+                SdkVersion = "unleash-client-mock:0.0.0",
                 CustomHttpHeaders = new Dictionary<string, string>()
                 {
                     { "Authorization", "*:default.some-mock-hash" }

--- a/tests/Unleash.Tests/Communication/UnleashApiClient_Project_Tests.cs
+++ b/tests/Unleash.Tests/Communication/UnleashApiClient_Project_Tests.cs
@@ -16,6 +16,8 @@ namespace Unleash.Tests.Communication
             {
                 AppName = "api-test-client",
                 InstanceTag = "instance1",
+                ConnectionId = "00000000-0000-4000-a000-000000000000",
+                SdkVersion = "unleash-client-mock:0.0.0",
                 CustomHttpHeaders = null,
                 CustomHttpHeaderProvider = null
             };

--- a/tests/Unleash.Tests/UnleashSettingsTests.cs
+++ b/tests/Unleash.Tests/UnleashSettingsTests.cs
@@ -22,7 +22,8 @@ namespace Unleash.Tests
             var settings = new UnleashSettings();
 
             // Assert
-            settings.SdkVersion.Should().StartWith("unleash-client-dotnet:v");
+            settings.SdkVersion.Should().StartWith("unleash-client-dotnet:");
+            settings.SdkVersion.Should().MatchRegex(@":\d+\.\d+\.\d+(-[0-9A-Za-z.-]+)?$");
         }
     }
 }


### PR DESCRIPTION
# Description

Identification headers consistent with other Unleash SDKs.

> This PR adds standardized client identification headers to the feature and metrics calls that the client makes to Unleash. The headers are:
> - `x-unleash-appname`: the name of the application that is using the client. `UNLEASH-APPNAME` will be deleted in another PR (expand/contract pattern)
> - `x-unleash-connection-id`: an internal unique identifier for the current instance of the client generated by the built-in crypto lib
> - `x-unleash-sdk`: sdk information in the format `unleash-client-<language>:<version>`
> 
> All the headers are intended for the Unleash team. Changes should be implemented in a way that does not change SDK behavior in a significant way.
> The main use cases we have are:
> * capacity planning by knowing the number of unique connections made to the backend API
> * debugging misconfigured SDKs sending more traffic than expected

Fixes [issue/1-3275](https://linear.app/unleash/issue/1-3275/uniqueness-headers-in-net-sdk)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Running unit tests locally
- [ ] Starting example app and verifying headers sent over the network

**Test Configuration**:
* Linux, dotnet 6.0.135

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules