### PR TITLE
fix: drop x prefix

### DIFF
--- a/src/Unleash/Communication/UnleashApiClient.cs
+++ b/src/Unleash/Communication/UnleashApiClient.cs
@@ -270,17 +270,15 @@ namespace Unleash.Communication
 
         private static void SetRequestHeaders(HttpRequestMessage requestMessage, UnleashApiClientRequestHeaders headers)
         {
-            const string appNameHeader = "UNLEASH-APPNAME";
             const string userAgentHeader = "User-Agent";
             const string instanceIdHeader = "UNLEASH-INSTANCEID";
 
-            const string identifyConnectionHeader = "x-unleash-connection-id";
-            const string identifyAppNameHeader = "x-unleash-appname";
-            const string identifySdkHeader = "x-unleash-sdk";
+            const string identifyConnectionHeader = "unleash-connection-id";
+            const string identifyAppNameHeader = "unleash-appname";
+            const string identifySdkHeader = "unleash-sdk";
 
             const string supportedSpecVersionHeader = "Unleash-Client-Spec";
 
-            requestMessage.Headers.TryAddWithoutValidation(appNameHeader, headers.AppName);
             requestMessage.Headers.TryAddWithoutValidation(userAgentHeader, headers.AppName);
             requestMessage.Headers.TryAddWithoutValidation(instanceIdHeader, headers.InstanceTag);
             requestMessage.Headers.TryAddWithoutValidation(supportedSpecVersionHeader, headers.SupportedSpecVersion);

--- a/tests/Unleash.Tests/Communication/CustomHeadersUnitTest.cs
+++ b/tests/Unleash.Tests/Communication/CustomHeadersUnitTest.cs
@@ -150,13 +150,13 @@ namespace Unleash.Tests.Communication
             foreach (var call in messageHandler.calls)
             {
                 call.Headers.Should().ContainEquivalentOf(
-                    new KeyValuePair<string, IEnumerable<string>>("x-unleash-connection-id", new string[] { "00000000-0000-4000-a000-000000000000" })
+                    new KeyValuePair<string, IEnumerable<string>>("unleash-connection-id", new string[] { "00000000-0000-4000-a000-000000000000" })
                 );
                 call.Headers.Should().ContainEquivalentOf(
-                    new KeyValuePair<string, IEnumerable<string>>("x-unleash-appname", new string[] { "api-test-client" })
+                    new KeyValuePair<string, IEnumerable<string>>("unleash-appname", new string[] { "api-test-client" })
                 );
                 call.Headers.Should().ContainEquivalentOf(
-                    new KeyValuePair<string, IEnumerable<string>>("x-unleash-sdk", new string[] { "unleash-client-mock:0.0.0" })
+                    new KeyValuePair<string, IEnumerable<string>>("unleash-sdk", new string[] { "unleash-client-mock:0.0.0" })
                 );
             }
         }


### PR DESCRIPTION
x- headers are deprecated (https://datatracker.ietf.org/doc/html/rfc6648). Let's use unleash- instead.