### PR TITLE
fix: prevent connection overwrite

### DIFF
--- a/src/Unleash/Communication/UnleashApiClient.cs
+++ b/src/Unleash/Communication/UnleashApiClient.cs
@@ -283,12 +283,13 @@ namespace Unleash.Communication
             requestMessage.Headers.TryAddWithoutValidation(instanceIdHeader, headers.InstanceTag);
             requestMessage.Headers.TryAddWithoutValidation(supportedSpecVersionHeader, headers.SupportedSpecVersion);
 
-            requestMessage.Headers.TryAddWithoutValidation(identifyConnectionHeader, headers.ConnectionId);
             requestMessage.Headers.TryAddWithoutValidation(identifyAppNameHeader, headers.AppName);
             requestMessage.Headers.TryAddWithoutValidation(identifySdkHeader, headers.SdkVersion);
 
             SetCustomHeaders(requestMessage, headers.CustomHttpHeaders);
             SetCustomHeaders(requestMessage, headers.CustomHttpHeaderProvider?.CustomHeaders);
+
+            requestMessage.Headers.TryAddWithoutValidation(identifyConnectionHeader, headers.ConnectionId);
         }
 
         private static void SetCustomHeaders(HttpRequestMessage requestMessage, Dictionary<string, string> headers)

--- a/tests/Unleash.Tests/Communication/CustomHeadersUnitTest.cs
+++ b/tests/Unleash.Tests/Communication/CustomHeadersUnitTest.cs
@@ -138,6 +138,10 @@ namespace Unleash.Tests.Communication
         [Test]
         public async Task IdentificationHttpHeaders()
         {
+            httpHeaders = new Dictionary<string, string>
+            {
+                {"unleash-connection-id", "ignore"}
+            };
             api = CreateApiClient();
             var engine = new YggdrasilEngine();
 

--- a/tests/Unleash.Tests/Communication/CustomHeadersUnitTest.cs
+++ b/tests/Unleash.Tests/Communication/CustomHeadersUnitTest.cs
@@ -138,10 +138,10 @@ namespace Unleash.Tests.Communication
         [Test]
         public async Task IdentificationHttpHeaders()
         {
-            httpHeaders = new Dictionary<string, string>
-            {
-                {"unleash-connection-id", "ignore"}
-            };
+//             httpHeaders = new Dictionary<string, string>
+//             {
+//                 {"unleash-connection-id", "ignore"}
+//             };
             api = CreateApiClient();
             var engine = new YggdrasilEngine();
 

--- a/tests/Unleash.Tests/Communication/CustomHeadersUnitTest.cs
+++ b/tests/Unleash.Tests/Communication/CustomHeadersUnitTest.cs
@@ -138,10 +138,6 @@ namespace Unleash.Tests.Communication
         [Test]
         public async Task IdentificationHttpHeaders()
         {
-//             httpHeaders = new Dictionary<string, string>
-//             {
-//                 {"unleash-connection-id", "ignore"}
-//             };
             api = CreateApiClient();
             var engine = new YggdrasilEngine();
 

--- a/tests/Unleash.Tests/Communication/RequestMessageHeadersTest.cs
+++ b/tests/Unleash.Tests/Communication/RequestMessageHeadersTest.cs
@@ -1,0 +1,19 @@
+using NUnit.Framework;
+
+namespace Unleash.Tests.Communication
+{
+    public class RequestMessageHeadersTest
+    {
+        [Test]
+        public void RequestMessageHeaders_Should_Contain_Headers()
+        {
+            var requestMessage = new HttpRequestMessage();
+            requestMessage.Headers.TryAddWithoutValidation("header1", "value1");
+            requestMessage.Headers.TryAddWithoutValidation("header1", "value2");
+
+            Assert.That(requestMessage.Headers.Count, Is.EqualTo(1));
+            Assert.That(requestMessage.Headers.First().Key, Is.EqualTo("header1"));
+            Assert.That(requestMessage.Headers.First().Value.Last(), Is.EqualTo("value2"));
+        }
+    }
+}


### PR DESCRIPTION
Prevent unleash-connection-id overwrite with a custom header.