### PR TITLE
feat: connectionId and interval in headers

### DIFF
--- a/src/Unleash/Communication/UnleashApiClient.cs
+++ b/src/Unleash/Communication/UnleashApiClient.cs
@@ -86,7 +86,7 @@ namespace Unleash.Communication
 
                 if (EntityTagHeaderValue.TryParse(etag, out var etagHeaderValue))
                     request.Headers.IfNoneMatch.Add(etagHeaderValue);
-                
+
                 using (var response = await httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false))
                 {
                     if (!response.IsSuccessStatusCode && response.StatusCode != HttpStatusCode.NotModified)

--- a/src/Unleash/Communication/UnleashApiClientRequestHeaders.cs
+++ b/src/Unleash/Communication/UnleashApiClientRequestHeaders.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 
 namespace Unleash.Communication
 {
@@ -11,5 +12,8 @@ namespace Unleash.Communication
         public Dictionary<string, string> CustomHttpHeaders { get; set; }
         public IUnleashCustomHttpHeaderProvider CustomHttpHeaderProvider { get; set; }
         public string SupportedSpecVersion { get; internal set; }
+        public TimeSpan SendMetricsInterval { get; set; }
+        public TimeSpan FetchTogglesInterval { get; set; }
+        
     }
 }

--- a/src/Unleash/Communication/UnleashApiClientRequestHeaders.cs
+++ b/src/Unleash/Communication/UnleashApiClientRequestHeaders.cs
@@ -14,6 +14,6 @@ namespace Unleash.Communication
         public string SupportedSpecVersion { get; internal set; }
         public TimeSpan SendMetricsInterval { get; set; }
         public TimeSpan FetchTogglesInterval { get; set; }
-        
+
     }
 }

--- a/src/Unleash/Metrics/ClientMetrics.cs
+++ b/src/Unleash/Metrics/ClientMetrics.cs
@@ -4,6 +4,7 @@ namespace Unleash.Metrics
     {
         public string AppName { get; set; }
         public string InstanceId { get; set; }
+        public string ConnectionId { get; set; }
         public Yggdrasil.MetricsBucket Bucket { get; set; }
         public string PlatformName
         {

--- a/src/Unleash/Metrics/ClientRegistration.cs
+++ b/src/Unleash/Metrics/ClientRegistration.cs
@@ -7,6 +7,7 @@ namespace Unleash.Metrics
     {
         public string AppName { get; set; }
         public string InstanceId { get; set; }
+        public string ConnectionId { get; set; }
         public string SdkVersion { get; set; }
         public List<string> Strategies { get; set; }
         public DateTimeOffset Started { get; set; }

--- a/tests/Unleash.Tests/Communication/CustomHeadersUnitTest.cs
+++ b/tests/Unleash.Tests/Communication/CustomHeadersUnitTest.cs
@@ -19,7 +19,9 @@ namespace Unleash.Tests.Communication
                 ConnectionId = "00000000-0000-4000-a000-000000000000",
                 SdkVersion = "unleash-client-mock:0.0.0",
                 CustomHttpHeaders = httpHeaders,
-                CustomHttpHeaderProvider = httpHeadersProvider
+                CustomHttpHeaderProvider = httpHeadersProvider,
+                FetchTogglesInterval = TimeSpan.FromSeconds(1),
+                SendMetricsInterval = TimeSpan.FromSeconds(2),
             };
 
             var httpClient = new HttpClient(messageHandler)
@@ -147,6 +149,19 @@ namespace Unleash.Tests.Communication
             await api.SendMetrics(engine.GetMetrics(), CancellationToken.None);
 
             messageHandler.calls.Count.Should().Be(3);
+
+
+
+            var fetchCall = messageHandler.calls[0];
+            fetchCall.Headers.Should().ContainEquivalentOf(
+                new KeyValuePair<string, IEnumerable<string>>("Unleash-Interval", new string[] { "1000" })
+            );
+
+            var metricsCall = messageHandler.calls[2];
+            metricsCall.Headers.Should().ContainEquivalentOf(
+                new KeyValuePair<string, IEnumerable<string>>("Unleash-Interval", new string[] { "2000" })
+            );
+
             foreach (var call in messageHandler.calls)
             {
                 call.Headers.Should().ContainEquivalentOf(

--- a/tests/Unleash.Tests/Communication/UnleasRequestBodyUnitTest.cs
+++ b/tests/Unleash.Tests/Communication/UnleasRequestBodyUnitTest.cs
@@ -1,0 +1,97 @@
+﻿using System.Text.Json;
+using FluentAssertions;
+using NUnit.Framework;
+using NUnit.Framework.Internal;
+using Unleash.Communication;
+using Unleash.Metrics;
+using Unleash.Tests.Mock;
+using Yggdrasil;
+
+namespace Unleash.Tests.Communication
+{
+    public class UnleasRequestBodyUnitTest
+    {
+        private IUnleashApiClient CreateApiClient()
+        {
+            var requestHeaders = new UnleashApiClientRequestHeaders
+            {
+                ConnectionId = "00000000-0000-4000-a000-000000000000",
+            };
+
+            var httpClient = new HttpClient(messageHandler)
+            {
+                BaseAddress = new Uri("http://example.com")
+            };
+            var client = new UnleashApiClient(httpClient, requestHeaders, null);
+            return client;
+        }
+
+        private class MockHttpMessageHandler : HttpMessageHandler
+        {
+            public List<HttpRequestMessage> calls
+            {
+                get;
+                set;
+            } = new List<HttpRequestMessage>();
+
+            protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                calls.Add(request);
+
+                bool isValidConnectionId = false;
+
+                if (request.Content != null)
+                {
+                    string requestBody = await request.Content.ReadAsStringAsync();
+
+                    using (JsonDocument doc = JsonDocument.Parse(requestBody))
+                    {
+                        if (doc.RootElement.TryGetProperty("connectionId", out JsonElement connectionIdElement))
+                        {
+                            if (connectionIdElement.ValueKind == JsonValueKind.String)
+                            {
+                                string connectionId = connectionIdElement.GetString();
+                                isValidConnectionId = connectionId == "00000000-0000-4000-a000-000000000000";
+                            }
+                        }
+                    }
+                }
+
+                return new HttpResponseMessage(isValidConnectionId ? System.Net.HttpStatusCode.OK : System.Net.HttpStatusCode.BadRequest);
+            }
+        }
+
+        private IUnleashApiClient api
+        {
+            get => TestExecutionContext.CurrentContext.CurrentTest.Properties.Get("api") as IUnleashApiClient;
+            set => TestExecutionContext.CurrentContext.CurrentTest.Properties.Set("api", value);
+        }
+
+        MockHttpMessageHandler messageHandler
+        {
+            get => TestExecutionContext.CurrentContext.CurrentTest.Properties.Get("messageHandler") as MockHttpMessageHandler;
+            set => TestExecutionContext.CurrentContext.CurrentTest.Properties.Set("messageHandler", value);
+        }
+
+        [SetUp]
+        public void SetupTest()
+        {
+            messageHandler = new MockHttpMessageHandler();
+        }
+
+
+        [Test]
+        public async Task IdentificationHttpHeaders()
+        {
+            api = CreateApiClient();
+
+            var engine = new YggdrasilEngine();
+            var metricsResult = await api.SendMetrics(engine.GetMetrics(), CancellationToken.None);
+            var registerResult = await api.RegisterClient(new Unleash.Metrics.ClientRegistration(), CancellationToken.None);
+
+            messageHandler.calls.Count.Should().Be(2);
+            metricsResult.Should().Be(true);
+            registerResult.Should().Be(true);
+        }
+    }
+}

--- a/tests/Unleash.Tests/Communication/UnleasRequestBodyUnitTest.cs
+++ b/tests/Unleash.Tests/Communication/UnleasRequestBodyUnitTest.cs
@@ -64,10 +64,10 @@ namespace Unleash.Tests.Communication
             var registerResult = await _apiClient.RegisterClient(new ClientRegistration(), CancellationToken.None);
 
             _messageHandler.Calls.Count.Should().Be(2);
-            _messageHandler.RequestBodies.All(body => ValidateRequestBody(body)).Should().BeTrue();
+            _messageHandler.RequestBodies.All(body => MatchesExpectedConnectionId(body)).Should().BeTrue();
         }
 
-        private bool ValidateRequestBody(string requestBody)
+        private bool MatchesExpectedConnectionId(string requestBody)
         {
             using (JsonDocument doc = JsonDocument.Parse(requestBody))
             {


### PR DESCRIPTION
Connection id is now on all headers and metrics/register endpoint.

Interval is on metrics and feature fetch.