### PR TITLE
chore(workflow): remove redundant dotnet-format tool install 

### DIFF
--- a/.github/workflows/prs.yml
+++ b/.github/workflows/prs.yml
@@ -23,9 +23,6 @@ jobs:
         with:
           dotnet-version: '6.0.x'
 
-      - name: Install dotnet format tool
-        run: dotnet tool install -g dotnet-format
-
       - name: Verify formatting
         run: dotnet format --verify-no-changes
         env:


### PR DESCRIPTION
Removes the dotnet-format tool install step from the workflow as should be included in >= .net 6 preview 7
