### PR TITLE
chore: bump yggdrasil to 1.0.6

### DIFF
--- a/src/Unleash/Unleash.csproj
+++ b/src/Unleash/Unleash.csproj
@@ -72,7 +72,7 @@
     <PackageReference Include="murmurhash" Version="1.0.3" />
     <PackageReference Include="NuGet.Versioning" Version="6.1.0" />
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="Unleash.Yggdrasil" Version="1.0.5" />
+    <PackageReference Include="Unleash.Yggdrasil" Version="1.0.6" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Bumps Yggdrasil dependency to 1.0.6 (fix for missing musl libraries)