### PR TITLE
chore: remove nuget.versioning and murmurhash dependencies no longer needed

### DIFF
--- a/src/Unleash/Unleash.csproj
+++ b/src/Unleash/Unleash.csproj
@@ -69,8 +69,6 @@
     <PackageReference Include="LibLog" Version="4.2.6">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="murmurhash" Version="1.0.3" />
-    <PackageReference Include="NuGet.Versioning" Version="6.1.0" />
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="Unleash.Yggdrasil" Version="1.0.6" />
   </ItemGroup>

--- a/tests/Unleash.Tests/Unleash.Tests.csproj
+++ b/tests/Unleash.Tests/Unleash.Tests.csproj
@@ -16,7 +16,6 @@
     <PackageReference Include="coverlet.collector" Version="3.1.2" />
     <PackageReference Include="FakeItEasy" Version="7.4.0" />
     <PackageReference Include="FluentAssertions" Version="6.11.0" />
-    <PackageReference Include="NuGet.Versioning" Version="6.6.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="NLog" Version="5.2.0" />
     <PackageReference Include="NLog.Config" Version="4.7.15" />

--- a/tests/Unleash.Tests/packages.config
+++ b/tests/Unleash.Tests/packages.config
@@ -6,7 +6,6 @@
   <package id="NLog" version="4.4.12" targetFramework="net47" />
   <package id="NLog.Config" version="4.4.12" targetFramework="net47" />
   <package id="NLog.Schema" version="4.4.12" targetFramework="net47" />
-  <package id="NuGet.Versioning" version="6.1.0" targetFramework="net47" />
   <package id="NUnit" version="3.12.0" targetFramework="net47" />
   <package id="NUnit3TestAdapter" version="3.15.1" targetFramework="net47" />
 </packages>


### PR DESCRIPTION
Cleans up no longer used dependencies NuGet.Versioning and murmurhash