### PR TITLE
fix: working etag

### DIFF
--- a/src/Unleash/Communication/UnleashApiClient.cs
+++ b/src/Unleash/Communication/UnleashApiClient.cs
@@ -150,7 +150,7 @@ namespace Unleash.Communication
         {
             featureRequestsToSkip = Math.Max(0, featureRequestsToSkip - 1);
 
-            var newEtag = response.Headers.ETag?.Tag;
+            var newEtag = response.Headers.ETag?.ToString();
             if (newEtag == etag || response.StatusCode == HttpStatusCode.NotModified)
             {
                 return new FetchTogglesResult

--- a/tests/Unleash.Tests/Communication/UnleashApiClient_Features_Tests.cs
+++ b/tests/Unleash.Tests/Communication/UnleashApiClient_Features_Tests.cs
@@ -1,0 +1,70 @@
+﻿using FluentAssertions;
+using NUnit.Framework;
+using Unleash.Communication;
+using Unleash.Internal;
+using Unleash.Serialization;
+using Unleash.Tests.Mock;
+
+namespace Unleash.Tests.Communication
+{
+    public class UnleashApiClient_Features_Tests
+    {
+        private UnleashApiClient NewTestableClient(MockHttpMessageHandler messageHandler)
+        {
+            var apiUri = new Uri("http://unleash.herokuapp.com/api/");
+
+            var jsonSerializer = new DynamicNewtonsoftJsonSerializer();
+            jsonSerializer.TryLoad();
+
+            var requestHeaders = new UnleashApiClientRequestHeaders
+            {
+                AppName = "api-test-client",
+                InstanceTag = "instance1",
+                CustomHttpHeaders = null,
+                CustomHttpHeaderProvider = null
+            };
+
+            var httpClient = new HttpClient(messageHandler)
+            {
+                BaseAddress = apiUri,
+                Timeout = TimeSpan.FromSeconds(5)
+            };
+
+            return new UnleashApiClient(httpClient, jsonSerializer, requestHeaders, new EventCallbackConfig());
+        }
+
+        [Test]
+        public async Task WeakEtagIsCorrectlyAddedToRequests()
+        {
+            var weakETag = "W/\"1d7-RkvEPkkxAVI06R3w4JXj3w==\"";
+            var messageHandler = new MockHttpMessageHandler();
+            messageHandler.ETagToReturn = weakETag;
+            var client = NewTestableClient(messageHandler);
+
+            var toggles = await client.FetchToggles(weakETag, CancellationToken.None);
+            toggles.HasChanged.Should().BeFalse();
+        }
+
+        [Test]
+        public async Task StrongEtagIsCorrectlyAddedToRequests()
+        {
+            var strongETag = "\"1d7-RkvEPkkxAVI06R3w4JXj3w==\"";
+            var messageHandler = new MockHttpMessageHandler();
+            messageHandler.ETagToReturn = strongETag;
+            var client = NewTestableClient(messageHandler);
+
+            var toggles = await client.FetchToggles(strongETag, CancellationToken.None);
+            toggles.HasChanged.Should().BeFalse();
+        }
+
+        [Test]
+        public async Task NoEtagReturnsEmptyToggles()
+        {
+            var messageHandler = new MockHttpMessageHandler();
+            var client = NewTestableClient(messageHandler);
+            var toggles = await client.FetchToggles(null, CancellationToken.None);
+            //cheating here because the SDK considers an empty response as no changes
+            toggles.Etag.Should().BeNull();
+        }
+    }
+}

--- a/tests/Unleash.Tests/Mock/MockHttpMessageHandler.cs
+++ b/tests/Unleash.Tests/Mock/MockHttpMessageHandler.cs
@@ -10,16 +10,25 @@ namespace Unleash.Tests.Mock
 {
     public class MockHttpMessageHandler : HttpMessageHandler
     {
-        public List<HttpRequestMessage> SentMessages = new List<HttpRequestMessage>();
+        public List<HttpRequestMessage> SentMessages { get; } = new List<HttpRequestMessage>();
+
+        public string? ETagToReturn { get; set; }
 
         protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
             SentMessages.Add(request);
 
-            return Task.FromResult(new HttpResponseMessage(System.Net.HttpStatusCode.OK)
+            var response = new HttpResponseMessage(System.Net.HttpStatusCode.OK)
             {
                 Content = new StringContent("{}", Encoding.UTF8, "application/json")
-            });
+            };
+
+            if (!string.IsNullOrEmpty(ETagToReturn))
+            {
+                response.Headers.ETag = System.Net.Http.Headers.EntityTagHeaderValue.Parse(ETagToReturn);
+            }
+
+            return Task.FromResult(response);
         }
     }
 }


### PR DESCRIPTION
Fixes an issue where weak etags are not correctly respected by the SDK. This is an issue because Edge tends to send weak etags