### PR TITLE
chore: relax branch constraint on release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,6 @@ name: Release
 on:
   release:
     types: [ published ]
-    branches: [ main ]
 
 jobs:
   build:


### PR DESCRIPTION
Should in theory let us release patches off the old v4 branch