### PR TITLE
chore: split CI runner into build and test steps so output is clearer

### DIFF
--- a/.github/workflows/prs.yml
+++ b/.github/workflows/prs.yml
@@ -28,5 +28,9 @@ jobs:
         env:
           PATH: ${{ github.env.PATH }}:/home/runner/.dotnet/tools
 
+      - name: Build test project
+        run: dotnet build tests/Unleash.Tests/Unleash.Tests.csproj --no-restore --configuration Release
+
       - name: Run tests
-        run: dotnet test tests/Unleash.Tests/Unleash.Tests.csproj --no-restore --verbosity normal
+        run: dotnet test tests/Unleash.Tests/Unleash.Tests.csproj --no-build --configuration Release --verbosity minimal
+


### PR DESCRIPTION
We currently get the output of the compile in the test run, which is over 1K lines of noise. Makes debugging a failed test run really annoying. This moves the compile noise to another task