### PR TITLE
fix: use Etag in FetchFeatureToggles

### DIFF
--- a/src/Unleash/Scheduling/FetchFeatureTogglesTask.cs
+++ b/src/Unleash/Scheduling/FetchFeatureTogglesTask.cs
@@ -86,6 +86,7 @@ namespace Unleash.Scheduling
             eventConfig?.RaiseTogglesUpdated(new TogglesUpdatedEvent { UpdatedOn = DateTime.UtcNow });
 
             backupManager.Save(new Backup(result.State, result.Etag));
+            Etag = result.Etag;
         }
 
         public string Name => "fetch-feature-toggles-task";

--- a/tests/Unleash.Tests/Internal/Etag_Tests.cs
+++ b/tests/Unleash.Tests/Internal/Etag_Tests.cs
@@ -1,0 +1,41 @@
+﻿using FakeItEasy;
+using NUnit.Framework;
+using Unleash.Communication;
+using Unleash.Internal;
+using Unleash.Scheduling;
+using Unleash.Tests.Mock;
+using Yggdrasil;
+
+namespace Unleash.Tests.Internal
+{
+    public class Etag_Tests
+    {
+        [Test]
+        public void Etag_Gets_Used_For_FetchToggles()
+        {
+            // Arrange
+            var fakeApiClient = A.Fake<IUnleashApiClient>();
+            A.CallTo(() => fakeApiClient.FetchToggles(null, A<CancellationToken>._, false))
+                .Returns(Task.FromResult(new FetchTogglesResult { HasChanged = true, State = "", Etag = "one" }));
+
+            A.CallTo(() => fakeApiClient.FetchToggles("one", A<CancellationToken>._, false))
+                .Returns(Task.FromResult(new FetchTogglesResult { HasChanged = true, State = "", Etag = "two" }));
+
+            var engine = new YggdrasilEngine();
+
+            var callbackConfig = new EventCallbackConfig();
+            var filesystem = new MockFileSystem();
+            var tokenSource = new CancellationTokenSource();
+            var backupManager = new NoOpBackupManager();
+            var task = new FetchFeatureTogglesTask(engine, fakeApiClient, filesystem, callbackConfig, backupManager, false);
+            Task.WaitAll(task.ExecuteAsync(tokenSource.Token));
+
+            // Act
+            Task.WaitAll(task.ExecuteAsync(tokenSource.Token));
+
+            // Assert
+            A.CallTo(() => fakeApiClient.FetchToggles("one", A<CancellationToken>._, false))
+                .MustHaveHappenedOnceExactly();
+        }
+    }
+}


### PR DESCRIPTION
# Description

Fixes a regression introduced in #299 which causes the Etag to not be used in subsequent requests to FetchToggles

Fixes # (issue)
#310

## Type of change



- [x] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?
Added a new unit test


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules