### PR TITLE
feat: rework dotnetcore sample app to be automatable

### DIFF
--- a/samples/DotnetCore/Dockerfile
+++ b/samples/DotnetCore/Dockerfile
@@ -1,0 +1,20 @@
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:9.0-alpine AS build
+
+ARG client_version
+
+COPY . /source
+WORKDIR /source
+
+ARG TARGETARCH
+# If TARGETARCH is "amd64", replace it with "x64" - "x64" is .NET's canonical name for this and "amd64" doesn't
+#   work in .NET
+RUN if [ -n "$client_version" ] ; then dotnet add package Unleash.Client --version ${client_version} ; fi
+RUN dotnet publish -a ${TARGETARCH/amd64/x64} --use-current-runtime --self-contained false -o /app
+
+FROM mcr.microsoft.com/dotnet/aspnet:9.0-alpine AS final
+
+WORKDIR /app
+COPY --from=build /app .
+
+USER $APP_UID
+ENTRYPOINT ["dotnet", "DotnetCore.dll"]

--- a/samples/DotnetCore/DotnetCore.csproj
+++ b/samples/DotnetCore/DotnetCore.csproj
@@ -8,10 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Unleash\Unleash.csproj">
-      <Project>{4cf2127b-8fc8-46fc-8614-3918148463a5}</Project>
-      <Name>Unleash</Name>
-    </ProjectReference>
+    <PackageReference Include="Unleash.Client" Version="5.5.3" />
   </ItemGroup>
 
 </Project>

--- a/samples/DotnetCore/Program.cs
+++ b/samples/DotnetCore/Program.cs
@@ -1,43 +1,43 @@
-﻿using Unleash;
+﻿using System.Diagnostics;
+using System.Security.Cryptography;
+using Unleash;
 using Unleash.ClientFactory;
-using Unleash.Strategies;
 
-var settings = new UnleashSettings()
+var unleashApi = Environment.GetEnvironmentVariable("UNLEASH_API");
+var unleashApiKey = Environment.GetEnvironmentVariable("UNLEASH_API_KEY");
+int.TryParse(Environment.GetEnvironmentVariable("UNLEASH_ENABLED_INTERVAL") ?? "200", out var enabledInterval);
+enabledInterval = enabledInterval > 10 ? enabledInterval : 10;
+
+var factory = new UnleashClientFactory();
+var unleash = await factory.CreateClientAsync(new UnleashSettings
 {
-    AppName = "dotnet-test",
-    UnleashApi = new Uri("http://localhost:4242/api"), //setup for running against a local unleash instance, feel free to change this
-    CustomHttpHeaders = new Dictionary<string, string>()
+    AppName = "dotnet-app",
+    UnleashApi = new Uri(unleashApi),
+    CustomHttpHeaders = new Dictionary<string, string>
     {
-      {"Authorization","add a valid client token here" }
+        { "Authorization", unleashApiKey }
     },
-    SendMetricsInterval = TimeSpan.FromSeconds(1)
-};
+});
 
-const string TOGGLE_NAME = "test";
-
-Console.WriteLine("Starting Unleash SDK");
-
-var unleashFactory = new UnleashClientFactory();
-IUnleash unleash = await unleashFactory.CreateClientAsync(settings, synchronousInitialization: true, new MyCustomStrategy());
-
-
-while (true)
+unleash.ConfigureEvents((cfg) =>
 {
-    var enabled = unleash.IsEnabled(TOGGLE_NAME);
-    var variant = unleash.GetVariant(TOGGLE_NAME);
+    cfg.ErrorEvent += (evt) => { Console.WriteLine($"Unleash Error: {evt}"); };
+});
 
-    Console.WriteLine($"Toggle enabled: {enabled}, variant: {System.Text.Json.JsonSerializer.Serialize(variant)}");
-    await Task.Delay(1000);
-}
-
-// If you want to test this, you'll need to setup a custom strategy in your
-// Unleash UI and add it to the 'test' toggle.
-class MyCustomStrategy : IStrategy
+System.Timers.Timer t = new System.Timers.Timer(200);
+t.Elapsed += (s, e) =>
 {
-    public string Name => "my-custom-strategy";
-
-    public bool IsEnabled(Dictionary<string, string> parameters, UnleashContext context)
+    var watch = Stopwatch.StartNew();
+    var flags = unleash.ListKnownToggles();
+    var elementAt = RandomNumberGenerator.GetInt32(flags.Count);
+    var variantFlag = flags.ElementAt(elementAt);
+    foreach (var flag in flags)
     {
-        return true;
+        var enabled = unleash.IsEnabled(flag.Name);
     }
-}
+    var variant = unleash.GetVariant(variantFlag.Name);
+    watch.Stop();
+    var elapsed = watch.ElapsedTicks;
+};
+t.Start();
+Console.ReadLine();


### PR DESCRIPTION
Reworks the dotnet core sample app so we can distribute it as container and use it to benchmark a bit