### PR TITLE
chore: post refactor cleanup, dispose scheduler properly

### DIFF
--- a/src/Unleash/DefaultUnleash.cs
+++ b/src/Unleash/DefaultUnleash.cs
@@ -137,6 +137,9 @@ namespace Unleash
             return Variant.UpgradeVariant(variant);
         }
 
+        private bool IsCustomScheduledTaskManager { get { return config.ScheduledTaskManager != null && !(config.ScheduledTaskManager is SystemTimerScheduledTaskManager); } }
+
+
         private UnleashConfig BuildUnleashConfig(
             UnleashSettings settings,
             bool synchronousInitialization,
@@ -230,6 +233,13 @@ namespace Unleash
             }
 
             services?.Dispose();
+            config.Engine?.Dispose();
+
+            if (IsCustomScheduledTaskManager)
+            {
+                Logger.Warn(() => $"UNLEASH: Disposing ScheduledTaskManager of type {config.ScheduledTaskManager.GetType().Name}");
+            }
+            config.ScheduledTaskManager.Dispose();
         }
     }
 }

--- a/src/Unleash/Internal/UnleashServices.cs
+++ b/src/Unleash/Internal/UnleashServices.cs
@@ -16,12 +16,9 @@ namespace Unleash
         private static readonly ILog Logger = LogProvider.GetLogger(typeof(UnleashServices));
         private int ready = 0;
 
-        private readonly IUnleashScheduledTaskManager scheduledTaskManager;
-
         private PollingFeatureFetcher PollingFeatureFetcher;
         private StreamingFeatureFetcher StreamingFeatureFetcher;
         private EventCallbackConfig EventConfig { get; }
-        private bool IsCustomScheduledTaskManager { get { return scheduledTaskManager != null && !(scheduledTaskManager is SystemTimerScheduledTaskManager); } }
 
 
         internal IUnleashContextProvider ContextProvider { get; }
@@ -112,17 +109,10 @@ namespace Unleash
 
         public void Dispose()
         {
-            engine?.Dispose();
-            if (IsCustomScheduledTaskManager)
-            {
-                Logger.Warn(() => $"UNLEASH: Disposing ScheduledTaskManager of type {scheduledTaskManager.GetType().Name}");
-            }
-
             PollingFeatureFetcher.OnReady -= OnHydrationSourceReadyHandler;
             PollingFeatureFetcher.Dispose();
             StreamingFeatureFetcher.OnReady -= OnHydrationSourceReadyHandler;
             StreamingFeatureFetcher.Dispose();
-            scheduledTaskManager?.Dispose();
         }
     }
 }

--- a/src/Unleash/Streaming/StreamingFeatureFetcher.cs
+++ b/src/Unleash/Streaming/StreamingFeatureFetcher.cs
@@ -75,7 +75,7 @@ namespace Unleash.Streaming
             {
                 case "unleash-connected":
                 case "unleash-updated":
-                    Logger.Debug(() => $"UNLEASH: Handling event '{data.EventName}'");
+                    Logger.Debug(() => $"UNLEASH: Handling event '{data.EventName}' with id '{data.Message.LastEventId}'");
                     HandleStreamingUpdate(data.Message.Data);
                     break;
                 case "fetch-mode":


### PR DESCRIPTION
So turns out post refactor we weren't disposing the scheduler again. I've fixed that and moved the responsibility out to the DefaultUnleash instance which is the one creating the UnleashConfig so seemed apt.

I also moved the disposing of the engine to the same place.
And added the processed event id to the debug logging of SSE processing