### PR TITLE
chore: bump yggdrasil version to 1.2.1

### DIFF
--- a/src/Unleash/DefaultUnleash.cs
+++ b/src/Unleash/DefaultUnleash.cs
@@ -29,7 +29,7 @@ namespace Unleash
 
         internal readonly MetricsService metrics;
 
-        public const string supportedSpecVersion = "5.1.9";
+        public const string supportedSpecVersion = "6.0.1";
 
         ///// <summary>
         ///// Initializes a new instance of Unleash client.

--- a/src/Unleash/Unleash.csproj
+++ b/src/Unleash/Unleash.csproj
@@ -51,7 +51,7 @@
     <PackageReference Include="LibLog" Version="4.2.6">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Unleash.Yggdrasil" Version="1.2.0" />
+    <PackageReference Include="Unleash.Yggdrasil" Version="1.2.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Bumps Yggdrasil engine version to 1.2.1, in preparation for releasing SDK version 6.1