### PR TITLE
chore: bump pr and release workflows to run .NET 8

### DIFF
--- a/.github/workflows/prs.yml
+++ b/.github/workflows/prs.yml
@@ -21,7 +21,7 @@ jobs:
 
       - uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '6.0.x'
+          dotnet-version: '8.0.x'
 
       - name: Verify formatting
         run: dotnet format --verify-no-changes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '6.0.x'
+          dotnet-version: '8.0.x'
 
       # Get NuGet setup for restoring, packaging and pushing
       - name: Setup NuGet


### PR DESCRIPTION
We've started using .NET 8 for tests - lets bump our workflows too so they can build