### PR TITLE
fix: prevent NullReferenceException in ToggleBootstrapFileProvider when using UseBootstrapFileProvider()

### DIFF
--- a/src/Unleash/UnleashSettings.cs
+++ b/src/Unleash/UnleashSettings.cs
@@ -105,10 +105,16 @@ namespace Unleash
         /// </summary>
         internal IUnleashApiClient UnleashApiClient { get; set; }
 
+        private IFileSystem _fileSystem;
+
         /// <summary>
         /// INTERNAL: Gets or sets the file system abstraction. Can be used for testing/mocking etc.
         /// </summary>
-        internal IFileSystem FileSystem { get; set; }
+        internal IFileSystem FileSystem
+        {
+            get => _fileSystem ?? new FileSystem(Encoding);
+            set => _fileSystem = value;
+        }
 
         /// <summary>
         /// Gets or sets the toggle bootstrap provider (file, url, etc). Can be used for testing/mocking etc.


### PR DESCRIPTION
# Description

The `FileSystem` internal property on `UnleashSettings` was never initialized before `ToggleBootstrapFileProvider.Read()` accessed it, causing a `NullReferenceException` when using `UseBootstrapFileProvider()`.

This change makes the `FileSystem` getter lazily return a new `FileSystem(Encoding)` instance when the backing field is null, ensuring the property is always usable without requiring explicit assignment.

Fixes #141

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Added regression test `Returns_File_Content_Without_Explicitly_Setting_FileSystem` in `ToggleBootstrapFileProvider_Tests` that verifies `UseBootstrapFileProvider()` works without explicitly setting `FileSystem`
- [x] All existing unit tests pass locally

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes