### PR TITLE
chore: leave scheduler cleanup to the cleanup method

### DIFF
--- a/src/Unleash/Scheduling/SystemTimerScheduledTaskManager.cs
+++ b/src/Unleash/Scheduling/SystemTimerScheduledTaskManager.cs
@@ -24,36 +24,43 @@ namespace Unleash.Scheduling
 
             async void Callback(object state)
             {
-                if (_shuttingDown) return;
-
                 try
                 {
-                    if (!cancellationToken.IsCancellationRequested)
+                    if (_shuttingDown) return;
+
+                    try
                     {
-                        await task.ExecuteAsync(cancellationToken);
+                        if (!cancellationToken.IsCancellationRequested)
+                        {
+                            await task.ExecuteAsync(cancellationToken);
+                        }
                     }
-                }
-                catch (TaskCanceledException taskCanceledException)
-                {
-                    if (!cancellationToken.IsCancellationRequested)
+                    catch (TaskCanceledException taskCanceledException)
                     {
-                        Logger.Warn(() => $"UNLEASH: Task '{name}' cancelled ...", taskCanceledException);
+                        if (!cancellationToken.IsCancellationRequested)
+                        {
+                            Logger.Warn(() => $"UNLEASH: Task '{name}' cancelled ...", taskCanceledException);
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        Logger.Warn(() => $"UNLEASH: Unhandled exception from background task '{name}'.", ex);
+                    }
+                    finally
+                    {
+                        if (cancellationToken.IsCancellationRequested)
+                        {
+                            // Stop the timer.
+                            if (timers.TryGetValue(name, out var timerToStop))
+                            {
+                                timerToStop.SafeTimerChange(Timeout.Infinite, Timeout.Infinite, ref _disposed);
+                            }
+                        }
                     }
                 }
                 catch (Exception ex)
                 {
-                    Logger.Warn(() => $"UNLEASH: Unhandled exception from background task '{name}'.", ex);
-                }
-                finally
-                {
-                    if (cancellationToken.IsCancellationRequested)
-                    {
-                        // Stop the timer.
-                        if (timers.TryGetValue(name, out var timerToStop))
-                        {
-                            timerToStop.SafeTimerChange(Timeout.Infinite, Timeout.Infinite, ref _disposed);
-                        }
-                    }
+                    Logger.Warn(() => $"UNLEASH: Unhandled exception escaped background task '{name}'.", ex);
                 }
             }
 

--- a/src/Unleash/Scheduling/SystemTimerScheduledTaskManager.cs
+++ b/src/Unleash/Scheduling/SystemTimerScheduledTaskManager.cs
@@ -24,25 +24,43 @@ namespace Unleash.Scheduling
 
             async void Callback(object state)
             {
-                if (_shuttingDown) return;
-
                 try
                 {
-                    if (!cancellationToken.IsCancellationRequested)
+                    if (_shuttingDown) return;
+
+                    try
                     {
-                        await task.ExecuteAsync(cancellationToken);
+                        if (!cancellationToken.IsCancellationRequested)
+                        {
+                            await task.ExecuteAsync(cancellationToken);
+                        }
                     }
-                }
-                catch (TaskCanceledException taskCanceledException)
-                {
-                    if (!cancellationToken.IsCancellationRequested)
+                    catch (TaskCanceledException taskCanceledException)
                     {
-                        Logger.Warn(() => $"UNLEASH: Task '{name}' cancelled ...", taskCanceledException);
+                        if (!cancellationToken.IsCancellationRequested)
+                        {
+                            Logger.Warn(() => $"UNLEASH: Task '{name}' cancelled ...", taskCanceledException);
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        Logger.Warn(() => $"UNLEASH: Unhandled exception from background task '{name}'.", ex);
+                    }
+                    finally
+                    {
+                        if (cancellationToken.IsCancellationRequested)
+                        {
+                            // Stop the timer.
+                            if (timers.TryGetValue(name, out var timerToStop))
+                            {
+                                timerToStop.SafeTimerChange(Timeout.Infinite, Timeout.Infinite, ref _disposed);
+                            }
+                        }
                     }
                 }
                 catch (Exception ex)
                 {
-                    Logger.Warn(() => $"UNLEASH: Unhandled exception from background task '{name}'.", ex);
+                    Logger.Warn(() => $"UNLEASH: Unhandled exception escaped background task '{name}'.", ex);
                 }
             }
 

--- a/src/Unleash/Scheduling/SystemTimerScheduledTaskManager.cs
+++ b/src/Unleash/Scheduling/SystemTimerScheduledTaskManager.cs
@@ -24,43 +24,25 @@ namespace Unleash.Scheduling
 
             async void Callback(object state)
             {
+                if (_shuttingDown) return;
+
                 try
                 {
-                    if (_shuttingDown) return;
-
-                    try
+                    if (!cancellationToken.IsCancellationRequested)
                     {
-                        if (!cancellationToken.IsCancellationRequested)
-                        {
-                            await task.ExecuteAsync(cancellationToken);
-                        }
+                        await task.ExecuteAsync(cancellationToken);
                     }
-                    catch (TaskCanceledException taskCanceledException)
+                }
+                catch (TaskCanceledException taskCanceledException)
+                {
+                    if (!cancellationToken.IsCancellationRequested)
                     {
-                        if (!cancellationToken.IsCancellationRequested)
-                        {
-                            Logger.Warn(() => $"UNLEASH: Task '{name}' cancelled ...", taskCanceledException);
-                        }
-                    }
-                    catch (Exception ex)
-                    {
-                        Logger.Warn(() => $"UNLEASH: Unhandled exception from background task '{name}'.", ex);
-                    }
-                    finally
-                    {
-                        if (cancellationToken.IsCancellationRequested)
-                        {
-                            // Stop the timer.
-                            if (timers.TryGetValue(name, out var timerToStop))
-                            {
-                                timerToStop.SafeTimerChange(Timeout.Infinite, Timeout.Infinite, ref _disposed);
-                            }
-                        }
+                        Logger.Warn(() => $"UNLEASH: Task '{name}' cancelled ...", taskCanceledException);
                     }
                 }
                 catch (Exception ex)
                 {
-                    Logger.Warn(() => $"UNLEASH: Unhandled exception escaped background task '{name}'.", ex);
+                    Logger.Warn(() => $"UNLEASH: Unhandled exception from background task '{name}'.", ex);
                 }
             }
 


### PR DESCRIPTION
Fixes a scheduler issue where clearing out the scheduler while a task is running would crash the entire app.
The fix is to remove the finally clause that contains the call to stopping the timer in the dictionary, and trusting the Dispose to do the job instead