### PR TITLE
fix: stop scheduled timer directly on cancellation

### DIFF
--- a/src/Unleash/Scheduling/SystemTimerScheduledTaskManager.cs
+++ b/src/Unleash/Scheduling/SystemTimerScheduledTaskManager.cs
@@ -21,6 +21,7 @@ namespace Unleash.Scheduling
         public void ConfigureTask(IUnleashScheduledTask task, CancellationToken cancellationToken, bool start)
         {
             var name = task.Name;
+            Timer timer = null;
 
             async void Callback(object state)
             {
@@ -48,10 +49,13 @@ namespace Unleash.Scheduling
                 {
                     if (cancellationToken.IsCancellationRequested)
                     {
-                        // Stop the timer.
-                        if (timers.TryGetValue(name, out var timerToStop))
+                        try
                         {
-                            timerToStop.SafeTimerChange(Timeout.Infinite, Timeout.Infinite, ref _disposed);
+                            timer.Change(Timeout.Infinite, Timeout.Infinite);
+                        }
+                        catch (ObjectDisposedException)
+                        {
+                            // Dispose won the race; the timer is already stopped.
                         }
                     }
                 }
@@ -65,8 +69,9 @@ namespace Unleash.Scheduling
                 ? Timeout.InfiniteTimeSpan
                 : task.Interval;
 
-            // Don't start the timer before it has been added to the dictionary.
-            var timer = new Timer(
+            // Keep the timer disabled until the captured variable has been assigned
+            // and the timer has been added to the dictionary.
+            timer = new Timer(
                 callback: Callback,
                 state: null,
                 dueTime: Timeout.Infinite,

--- a/tests/Unleash.Tests/Scheduling/SystemTimerScheduledTaskManagerTests.cs
+++ b/tests/Unleash.Tests/Scheduling/SystemTimerScheduledTaskManagerTests.cs
@@ -1,0 +1,111 @@
+using FluentAssertions;
+using NUnit.Framework;
+using Unleash.Scheduling;
+
+namespace Unleash.Tests.Scheduling;
+
+[NonParallelizable]
+public class SystemTimerScheduledTaskManagerTests
+{
+    [Test]
+    public async Task Cancellation_stops_a_repeating_timer_without_disposing_the_manager()
+    {
+        var activeTimersBeforeTest = Timer.ActiveCount;
+        using var cancellationTokenSource = new CancellationTokenSource();
+        using var manager = new SystemTimerScheduledTaskManager();
+        var task = new CancellationAwareTask();
+
+        manager.ConfigureTask(task, cancellationTokenSource.Token, true);
+        await task.Started.Task.WaitAsync(TimeSpan.FromSeconds(1));
+
+        cancellationTokenSource.Cancel();
+        await task.Cancelled.Task.WaitAsync(TimeSpan.FromSeconds(1));
+
+        await WaitUntilAsync(
+            () => Timer.ActiveCount == activeTimersBeforeTest,
+            TimeSpan.FromSeconds(1));
+    }
+
+    [Test]
+    public async Task Callback_tolerates_disposal_winning_the_cancellation_race()
+    {
+        var activeTimersBeforeTest = Timer.ActiveCount;
+        using var cancellationTokenSource = new CancellationTokenSource();
+        var manager = new SystemTimerScheduledTaskManager();
+        var task = new BlockingTask();
+
+        manager.ConfigureTask(task, cancellationTokenSource.Token, true);
+        await task.Started.Task.WaitAsync(TimeSpan.FromSeconds(1));
+
+        manager.Dispose();
+        cancellationTokenSource.Cancel();
+        task.Release.TrySetResult();
+        await task.Completed.Task.WaitAsync(TimeSpan.FromSeconds(1));
+        await Task.Delay(50);
+
+        await WaitUntilAsync(
+            () => Timer.ActiveCount == activeTimersBeforeTest,
+            TimeSpan.FromSeconds(1));
+    }
+
+    private static async Task WaitUntilAsync(Func<bool> condition, TimeSpan timeout)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+        while (!condition() && DateTime.UtcNow < deadline)
+        {
+            await Task.Delay(10);
+        }
+
+        condition().Should().BeTrue();
+    }
+
+    private sealed class CancellationAwareTask : IUnleashScheduledTask
+    {
+        public TaskCompletionSource Started { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public TaskCompletionSource Cancelled { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public string Name => nameof(CancellationAwareTask);
+        public TimeSpan Interval => TimeSpan.FromMilliseconds(10);
+        public bool ExecuteDuringStartup => true;
+
+        public async Task ExecuteAsync(CancellationToken cancellationToken)
+        {
+            Started.TrySetResult();
+
+            try
+            {
+                await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+            }
+            finally
+            {
+                Cancelled.TrySetResult();
+            }
+        }
+    }
+
+    private sealed class BlockingTask : IUnleashScheduledTask
+    {
+        public TaskCompletionSource Started { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public TaskCompletionSource Release { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public TaskCompletionSource Completed { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public string Name => nameof(BlockingTask);
+        public TimeSpan Interval => TimeSpan.FromMilliseconds(10);
+        public bool ExecuteDuringStartup => true;
+
+        public async Task ExecuteAsync(CancellationToken cancellationToken)
+        {
+            Started.TrySetResult();
+            await Release.Task;
+            Completed.TrySetResult();
+        }
+    }
+}


### PR DESCRIPTION
## Context

This is an alternative exploration to #350. It tries to preserve cancellation-driven timer cleanup while avoiding callback access to the shared `timers` dictionary.

Related discussion:
- https://github.com/Unleash/unleash-dotnet-sdk/pull/350
- https://github.com/Unleash/unleash-dotnet-sdk/pull/350#issuecomment-5353437228

## Approach

- Capture the disabled `Timer` created for the callback and stop that instance directly when cancellation is observed.
- Treat `ObjectDisposedException` as the expected outcome when scheduler disposal wins the race.
- Leave `SystemTimerScheduledTaskManager.Dispose()` responsible for disposing timers and clearing the dictionary.
- Avoid a `ConcurrentDictionary` and avoid check-then-act synchronization through `_shuttingDown`.

The capture is initialized safely: the timer is created with `Timeout.Infinite`, assigned to the captured local, added to the dictionary, and only then started.

## Tests

Added focused coverage for:
- cancellation stopping a repeating timer without manager disposal;
- disposal completing while an async callback is suspended, followed by cancellation and callback continuation.

Local verification:
- `dotnet format Unleash.sln --verify-no-changes --no-restore` — passed
- Release build — passed
- focused scheduler tests — 2 passed
- full test suite under the locally installed .NET 10 runtime with major roll-forward — 401 passed, 1 unrelated streaming test failed (`Switches_To_Polling_When_Too_Many_Http_Errors`); it also fails in isolation and uses a custom scheduler rather than the changed implementation. Repository CI runs the suite on its native .NET 8 runtime.
